### PR TITLE
Fix Zephyr USB branch

### DIFF
--- a/config/zephyr/generic/board.repos
+++ b/config/zephyr/generic/board.repos
@@ -2,4 +2,4 @@ repositories:
   zephyr_apps:
     type: git
     url: https://github.com/micro-ROS/zephyr_apps
-    version: foxy
+    version: feature/fix_zephyr_usb


### PR DESCRIPTION
This PR check the CI integration with the Zephyr USB fix here: https://github.com/micro-ROS/zephyr_apps/pull/17

DONT MERGE. CLOSE WHEN https://github.com/micro-ROS/zephyr_apps/pull/17 MERGED