### PR TITLE
Add support for nucleo_h743zi with Zephyr

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,12 @@ jobs:
             binary: 'firmware/build/zephyr/zephyr.bin'
 
           - rtos: zephyr
+            platform: nucleo_h743zi
+            configuration: int32_publisher
+            transport_arguments: -t serial -d 3
+            binary: 'firmware/build/zephyr/zephyr.bin'
+
+          - rtos: zephyr
             platform: host
             configuration: ping_pong
             transport_arguments: -t udp -i 192.168.1.1 -p 8080

--- a/NOTICE
+++ b/NOTICE
@@ -28,3 +28,6 @@ eProsima
 Robert Bosch GmbH
     Ingo Lütkebohle  <ingo.luetkebohle@de.bosch.com>
     Ralph Lange <ralph.lange@de.bosch.com>
+
+Boston Engineering
+    Connor Lansdale <clansdale@boston-engineering.com>

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This ROS 2 package is the entry point for building micro-ROS apps for different 
 | [FreeRTOS](https://www.freertos.org/)    | [Espressif ESP32](https://www.espressif.com/en/products/socs/esp32/overview)                         | v8.2.0               | `freertos esp32`             |
 | [Zephyr](https://www.zephyrproject.org/) | [Olimex STM32-E407](https://www.olimex.com/Products/ARM/ST/STM32-E407/open-source-hardware)          | v2.3.0               | `zephyr olimex-stm32-e407`   |
 | [Zephyr](https://www.zephyrproject.org/) | [ST B-L475E-IOT01A](https://docs.zephyrproject.org/latest/boards/arm/disco_l475_iot1/doc/index.html) | v2.3.0               | `zephyr discovery_l475_iot1` |
+| [Zephyr](https://www.zephyrproject.org/) | [ST Nucleo H743ZI](https://www.st.com/en/evaluation-tools/nucleo-h743zi.html) <sup>1</sup>           | v2.3.0               | `zephyr nucleo_h743zi`       |
 | [Zephyr](https://www.zephyrproject.org/) | [Zephyr emulator](https://docs.zephyrproject.org/2.3.0/boards/posix/native_posix/doc/index.html)     | v2.3.0               | `zephyr host`                |
 | Linux                                    | *Host <sup>2</sup>*                                                                                             | Ubuntu 18.04/20.04   | `host`                       |
 
@@ -116,6 +117,7 @@ In summary, the supported configurations for transports are:
 | Crazyflie 2.1      |         -          | Custom Radio Link |         -          |
 | Espressif ESP32    |         -          |  UART, WiFI UDP   |         -          |
 | ST Nucleo F446ZE <sup>1</sup> |         -          |       UART        |         -          |
+| ST Nucleo H743ZI <sup>1</sup> |         -          |       -        |         UART          |
 
 *<sup>1</sup> Community supported, may have lack of official support*
 

--- a/config/zephyr/generic/build.sh
+++ b/config/zephyr/generic/build.sh
@@ -36,6 +36,8 @@ pushd $FW_TARGETDIR >/dev/null
         export BOARD="olimex_stm32_e407"
     elif [ "$PLATFORM" = "nucleo_f401re" ]; then
         export BOARD="nucleo_f401re"
+    elif [ "$PLATFORM" = "nucleo_h743zi" ]; then
+        export BOARD="nucleo_h743zi"
     elif [ "$PLATFORM" = "host" ]; then
         export BOARD="native_posix"
     else

--- a/config/zephyr/generic/flash.sh
+++ b/config/zephyr/generic/flash.sh
@@ -25,6 +25,15 @@ elif [ "$PLATFORM" = "olimex-stm32-e407" ]; then
       fi
 
       openocd -f $PROGRAMMER -f target/stm32f4x.cfg -c init -c "reset halt" -c "flash write_image erase build/zephyr/zephyr.bin 0x08000000" -c "reset" -c "exit"
+
+  elif [ "$PLATFORM" = "nucleo_h743zi" ]; then
+    if lsusb -d 0483:374e;then
+        PROGRAMMER=interface/stlink.cfg
+        TARGET=stm32h7x.cfg
+    fi
+
+    openocd -f $PROGRAMMER -f target/$TARGET -c init -c "reset halt" -c "flash write_image erase build/zephyr/zephyr.bin 0x08000000" -c "reset run; exit"
+
   else
     echo "build/zephyr/zephyr.bin not found: please compile before flashing."
   fi

--- a/config/zephyr/generic/supported_platforms
+++ b/config/zephyr/generic/supported_platforms
@@ -1,3 +1,4 @@
 discovery_l475_iot1
 olimex-stm32-e407
 nucleo_f401re
+nucleo_h743zi

--- a/scripts/create_firmware_ws.sh
+++ b/scripts/create_firmware_ws.sh
@@ -71,7 +71,6 @@ echo $PLATFORM >> $FW_TARGETDIR/PLATFORM
 SKIP="microxrcedds_agent microxrcedds_client microcdr rosidl_typesupport_connext_cpp rosidl_typesupport_connext_c rosidl_typesupport_opensplice_cpp rosidl_typesupport_opensplice_c rmw_connext_cpp rmw_opensplice_cpp ros-foxy-cyclonedds ros-foxy-rmw-cyclonedds-cpp"
 
 # Installing common packages 
-sudo apt update
 rosdep update
 rosdep install -y --from-paths src -i src --rosdistro foxy --skip-keys="$SKIP"
 


### PR DESCRIPTION
Add board support to the appropriate files.

'sudo apt update' was also taken out of create_firmware_ws.sh so that it doesn't need to be run as root. Not sure how best to catch the error that comes up if apt is not up to date, it is recommended in the tutorials to update before running, but perhaps that is not enough. 

These changes have been tested with serial transport only.

Note: In order to run examples without any modifications, this pull request will need to be merged in lockstep with changes to the [zephyr_apps repo here](https://github.com/micro-ROS/zephyr_apps/pull/18)