### PR TITLE
Add custom app folder in Zephyr

### DIFF
--- a/config/zephyr/generic/build.sh
+++ b/config/zephyr/generic/build.sh
@@ -12,7 +12,12 @@ pushd $FW_TARGETDIR >/dev/null
     unset UROS_APP
             
     export UROS_APP=$(head -n1 $FW_TARGETDIR/APP | tail -n1)
-    export UROS_APP_FOLDER="$FW_TARGETDIR/zephyr_apps/apps/$UROS_APP"
+
+    if [ -v UROS_CUSTOM_APP_FOLDER ]; then
+        export UROS_APP_FOLDER="$UROS_CUSTOM_APP_FOLDER/$UROS_APP"
+    else
+        export UROS_APP_FOLDER="$FW_TARGETDIR/zephyr_apps/apps/$UROS_APP"
+    fi
 
     if [ -d "$UROS_APP_FOLDER" ]; then
         echo "Selected app: $UROS_APP"

--- a/config/zephyr/generic/build.sh
+++ b/config/zephyr/generic/build.sh
@@ -69,5 +69,5 @@ pushd $FW_TARGETDIR >/dev/null
     fi
 
     # Build Zephyr + app
-    west build -b $BOARD -p auto $UROS_APP_FOLDER -- -DCONF_FILE=$UROS_APP_FOLDER/$CONF_FILE -G'Unix Makefiles' -DCMAKE_VERBOSE_MAKEFILE=ON
+    west build -b $BOARD -p auto $UROS_APP_FOLDER -- -DCONF_FILE=$UROS_APP_FOLDER/$CONF_FILE -G'Unix Makefiles' -DCMAKE_VERBOSE_MAKEFILE=ON -DMICRO_ROS_FIRMWARE_DIR=$FW_TARGETDIR
 popd >/dev/null

--- a/config/zephyr/list_apps.sh
+++ b/config/zephyr/list_apps.sh
@@ -1,14 +1,28 @@
 function print_available_apps {
   echo "Available apps for Zephyr and $PLATFORM:"
-  pushd $FW_TARGETDIR/zephyr_apps/apps >/dev/null
-  for app in $(ls -d */ | cut -f1 -d'/'); do 
-    echo "+-- $app"
-  done
+
+  if [ -v UROS_CUSTOM_APP_FOLDER ]; then
+    UROS_ZEPHYR_APPS=$UROS_CUSTOM_APP_FOLDER
+  else
+    UROS_ZEPHYR_APPS=$FW_TARGETDIR/zephyr_apps/apps
+  fi
+
+  pushd $UROS_ZEPHYR_APPS >/dev/null
+    for app in $(ls -d */ | cut -f1 -d'/'); do 
+      echo "+-- $app"
+    done
   popd >/dev/null
 }
 
 function check_available_app {
-  pushd $FW_TARGETDIR/zephyr_apps/apps >/dev/null
+  
+  if [ -v UROS_CUSTOM_APP_FOLDER ]; then
+    UROS_ZEPHYR_APPS=$UROS_CUSTOM_APP_FOLDER
+  else
+    UROS_ZEPHYR_APPS=$FW_TARGETDIR/zephyr_apps/apps
+  fi
+
+  pushd $UROS_ZEPHYR_APPS >/dev/null
     if [ ! -d $1 ]; then
         echo "App $1 for Zephyr not available"
         print_available_apps


### PR DESCRIPTION
This PR enables using external applications in Zephyr by using `UROS_CUSTOM_APP_FOLDER`