### PR TITLE
Added lines to build typesupport earlier

### DIFF
--- a/config/host/generic/build.sh
+++ b/config/host/generic/build.sh
@@ -1,2 +1,4 @@
 #!/bin/bash
+colcon build --packages-up-to rosidl_typesupport_microxrcedds_c --metas src $@
+colcon build --packages-up-to rosidl_typesupport_microxrcedds_cpp --metas src $@
 colcon build --metas src $@


### PR DESCRIPTION
This PR adds build steps for `rosidl_typesupport_microxrcedds_c` and `rosidl_typesupport_microxrcedds_cpp` before building the whole micro-ROS workspace for host in order to generate the packages typesupport libraries correctly.

Related: https://github.com/ros2/rosidl/issues/520

Workaround for: https://github.com/micro-ROS/micro_ros_setup/issues/184