### PR TITLE
Test new rcutils and rcl repos

### DIFF
--- a/config/freertos/crazyflie21/client_uros_packages.repos
+++ b/config/freertos/crazyflie21/client_uros_packages.repos
@@ -13,7 +13,7 @@ repositories:
   uros/rcl:
     type: git
     url: https://github.com/micro-ROS/rcl
-    version: foxy
+    version: feature/foxy_upgrade_09102020
   uros/rclc:
     type: git
     url: https://github.com/micro-ROS/rclc
@@ -21,15 +21,15 @@ repositories:
   uros/rcutils:
     type: git
     url: https://github.com/micro-ROS/rcutils
-    version: foxy
+    version: feature/foxy_upgrade_09102020
   uros/rmw_microxrcedds:
     type: git
     url: https://github.com/micro-ROS/rmw-microxrcedds.git
     version: foxy
   uros/rosidl_typesupport:
     type: git
-    url: https://github.com/micro-ROS/rosidl_typesupport.git
-    version: foxy
+    url: https://github.com/micro-ROS/rosidl_typesupport
+    version: feature/foxy_upgrade_09102020
   uros/rosidl_typesupport_microxrcedds:
     type: git
     url: https://github.com/micro-ROS/rosidl_typesupport_microxrcedds.git

--- a/config/freertos/esp32/client_uros_packages.repos
+++ b/config/freertos/esp32/client_uros_packages.repos
@@ -13,7 +13,7 @@ repositories:
   uros/rcl:
     type: git
     url: https://github.com/micro-ROS/rcl
-    version: foxy
+    version: feature/foxy_upgrade_09102020
   uros/rclc:
     type: git
     url: https://github.com/micro-ROS/rclc
@@ -21,15 +21,15 @@ repositories:
   uros/rcutils:
     type: git
     url: https://github.com/micro-ROS/rcutils
-    version: foxy
+    version: feature/foxy_upgrade_09102020
   uros/rmw_microxrcedds:
     type: git
     url: https://github.com/micro-ROS/rmw-microxrcedds.git
     version: foxy
   uros/rosidl_typesupport:
     type: git
-    url: https://github.com/micro-ROS/rosidl_typesupport.git
-    version: foxy
+    url: https://github.com/micro-ROS/rosidl_typesupport
+    version: feature/foxy_upgrade_09102020
   uros/rosidl_typesupport_microxrcedds:
     type: git
     url: https://github.com/micro-ROS/rosidl_typesupport_microxrcedds.git

--- a/config/freertos/nucleo_f446ze/client_uros_packages.repos
+++ b/config/freertos/nucleo_f446ze/client_uros_packages.repos
@@ -13,7 +13,7 @@ repositories:
   uros/rcl:
     type: git
     url: https://github.com/micro-ROS/rcl
-    version: foxy
+    version: feature/foxy_upgrade_09102020
   uros/rclc:
     type: git
     url: https://github.com/micro-ROS/rclc
@@ -21,15 +21,15 @@ repositories:
   uros/rcutils:
     type: git
     url: https://github.com/micro-ROS/rcutils
-    version: foxy
+    version: feature/foxy_upgrade_09102020
   uros/rmw_microxrcedds:
     type: git
     url: https://github.com/micro-ROS/rmw-microxrcedds.git
     version: foxy
   uros/rosidl_typesupport:
     type: git
-    url: https://github.com/micro-ROS/rosidl_typesupport.git
-    version: foxy
+    url: https://github.com/micro-ROS/rosidl_typesupport
+    version: feature/foxy_upgrade_09102020
   uros/rosidl_typesupport_microxrcedds:
     type: git
     url: https://github.com/micro-ROS/rosidl_typesupport_microxrcedds.git

--- a/config/freertos/nucleo_f746zg/client_uros_packages.repos
+++ b/config/freertos/nucleo_f746zg/client_uros_packages.repos
@@ -13,7 +13,7 @@ repositories:
   uros/rcl:
     type: git
     url: https://github.com/micro-ROS/rcl
-    version: foxy
+    version: feature/foxy_upgrade_09102020
   uros/rclc:
     type: git
     url: https://github.com/micro-ROS/rclc
@@ -21,15 +21,15 @@ repositories:
   uros/rcutils:
     type: git
     url: https://github.com/micro-ROS/rcutils
-    version: foxy
+    version: feature/foxy_upgrade_09102020
   uros/rmw_microxrcedds:
     type: git
     url: https://github.com/micro-ROS/rmw-microxrcedds.git
     version: foxy
   uros/rosidl_typesupport:
     type: git
-    url: https://github.com/micro-ROS/rosidl_typesupport.git
-    version: foxy
+    url: https://github.com/micro-ROS/rosidl_typesupport
+    version: feature/foxy_upgrade_09102020
   uros/rosidl_typesupport_microxrcedds:
     type: git
     url: https://github.com/micro-ROS/rosidl_typesupport_microxrcedds.git

--- a/config/freertos/olimex-stm32-e407/client_uros_packages.repos
+++ b/config/freertos/olimex-stm32-e407/client_uros_packages.repos
@@ -13,7 +13,7 @@ repositories:
   uros/rcl:
     type: git
     url: https://github.com/micro-ROS/rcl
-    version: foxy
+    version: feature/foxy_upgrade_09102020
   uros/rclc:
     type: git
     url: https://github.com/micro-ROS/rclc
@@ -21,15 +21,15 @@ repositories:
   uros/rcutils:
     type: git
     url: https://github.com/micro-ROS/rcutils
-    version: foxy
+    version: feature/foxy_upgrade_09102020
   uros/rmw_microxrcedds:
     type: git
     url: https://github.com/micro-ROS/rmw-microxrcedds.git
     version: foxy
   uros/rosidl_typesupport:
     type: git
-    url: https://github.com/micro-ROS/rosidl_typesupport.git
-    version: foxy
+    url: https://github.com/micro-ROS/rosidl_typesupport
+    version: feature/foxy_upgrade_09102020
   uros/rosidl_typesupport_microxrcedds:
     type: git
     url: https://github.com/micro-ROS/rosidl_typesupport_microxrcedds.git

--- a/config/nuttx/generic/client_uros_packages.repos
+++ b/config/nuttx/generic/client_uros_packages.repos
@@ -13,7 +13,7 @@ repositories:
   uros/rcl:
     type: git
     url: https://github.com/micro-ROS/rcl.git
-    version: foxy
+    version: feature/foxy_upgrade_09102020
   uros/rclc:
     type: git
     url: https://github.com/micro-ROS/rclc.git
@@ -25,7 +25,7 @@ repositories:
   uros/rcutils:
     type: git
     url: https://github.com/micro-ROS/rcutils.git
-    version: foxy
+    version: feature/foxy_upgrade_09102020
   drive_base:
     type: git
     url: https://github.com/micro-ROS/drive_base.git
@@ -36,8 +36,8 @@ repositories:
     version: foxy_microros
   uros/rosidl_typesupport:
     type: git
-    url: https://github.com/micro-ROS/rosidl_typesupport.git
-    version: foxy
+    url: https://github.com/micro-ROS/rosidl_typesupport
+    version: feature/foxy_upgrade_09102020
   uros/rosidl_typesupport_microxrcedds:
     type: git
     url: https://github.com/micro-ROS/rosidl_typesupport_microxrcedds.git

--- a/config/zephyr/generic/client_uros_packages.repos
+++ b/config/zephyr/generic/client_uros_packages.repos
@@ -13,7 +13,7 @@ repositories:
   uros/rcl:
     type: git
     url: https://github.com/micro-ROS/rcl
-    version: foxy
+    version: feature/foxy_upgrade_09102020
   uros/rclc:
     type: git
     url: https://github.com/micro-ROS/rclc
@@ -25,15 +25,15 @@ repositories:
   uros/rcutils:
     type: git
     url: https://github.com/micro-ROS/rcutils
-    version: foxy
+    version: feature/foxy_upgrade_09102020
   uros/rmw_microxrcedds:
     type: git
     url: https://github.com/micro-ROS/rmw-microxrcedds.git
     version: foxy
   uros/rosidl_typesupport:
     type: git
-    url: https://github.com/micro-ROS/rosidl_typesupport.git
-    version: foxy
+    url: https://github.com/micro-ROS/rosidl_typesupport
+    version: feature/foxy_upgrade_09102020
   uros/rosidl_typesupport_microxrcedds:
     type: git
     url: https://github.com/micro-ROS/rosidl_typesupport_microxrcedds.git


### PR DESCRIPTION
This PR test CI for new branches of RCUtils and RCL rebased to ROS 2 branches on 09/10/2020

Related to Foxy sync: https://discourse.ros.org/t/new-packages-and-patch-release-for-foxy-fitzroy-2020-10-09/16760

Once CI pass, [rcutils branch for micro-ROS](https://github.com/micro-ROS/rcl), [rcl branch for micro-ROS](https://github.com/micro-ROS/rcl) and [rosidl_typesupport branch for micro-ROS](https://github.com/micro-ROS/rosidl_typesupport) will be upgraded and this PR will be closed.