### PR TITLE
Disable XRCE P2P Agent for micro-ROS

### DIFF
--- a/scripts/build_agent.sh
+++ b/scripts/build_agent.sh
@@ -6,6 +6,7 @@ set -o pipefail
 
 echo "Building micro-ROS Agent"
 
-colcon build $@ --cmake-args \
+colcon build --packages-select micro_ros_agent microxrcedds_agent drive_base_msgs $@ --cmake-args \
     "-DUAGENT_BUILD_EXECUTABLE=OFF" \
+    "-DUAGENT_P2P_PROFILE=OFF" \
     "--no-warn-unused-cli"


### PR DESCRIPTION
This PR disables the Agent CED middleware functionality when building a micro-ROS agent.

Solves https://github.com/micro-ROS/micro-ROS.github.io/issues/221