### PR TITLE
Add -v cli flag to build step to control amount of build output

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -29,5 +29,7 @@ Robert Bosch GmbH
     Ingo Lütkebohle  <ingo.luetkebohle@de.bosch.com>
     Ralph Lange <ralph.lange@de.bosch.com>
 
+Robert Wilbrandt <robert@stamm-wilbrandt.de>
+
 Boston Engineering
     Connor Lansdale <clansdale@boston-engineering.com>

--- a/config/zephyr/generic/build.sh
+++ b/config/zephyr/generic/build.sh
@@ -70,6 +70,11 @@ pushd $FW_TARGETDIR >/dev/null
         export CONF_FILE="host-udp.conf"
     fi
 
+    # Check build argument parameters
+    if [ -z "$UROS_VERBOSE_BUILD" ]; then
+      UROS_VERBOSE_BUILD=off
+    fi
+
     # Build Zephyr + app
-    west build -b $BOARD -p auto $UROS_APP_FOLDER -- -DCONF_FILE=$UROS_APP_FOLDER/$CONF_FILE -G'Unix Makefiles' -DCMAKE_VERBOSE_MAKEFILE=ON -DMICRO_ROS_FIRMWARE_DIR=$FW_TARGETDIR
+    west build -b $BOARD -p auto $UROS_APP_FOLDER -- -DCONF_FILE=$UROS_APP_FOLDER/$CONF_FILE -G'Unix Makefiles' -DCMAKE_VERBOSE_MAKEFILE=$UROS_VERBOSE_BUILD -DMICRO_ROS_FIRMWARE_DIR=$FW_TARGETDIR
 popd >/dev/null

--- a/scripts/build_firmware.sh
+++ b/scripts/build_firmware.sh
@@ -8,15 +8,27 @@ PREFIXES_TO_CLEAN=$AMENT_PREFIX_PATH
 FW_TARGETDIR=$(pwd)/firmware
 PREFIX=$(ros2 pkg prefix micro_ros_setup)
 
+# Parse cli arguments
 UROS_FAST_BUILD=off
-if [ $# -gt 0 ]; then
-    if [ "$1" = "-f" ]; then
-      echo "Fast-Build active, ROS workspace will not be re-built!"
-      export UROS_FAST_BUILD=y
-      shift
-    fi
-fi
+UROS_VERBOSE_BUILD=off
+for param in "$@"
+do
+  case $param in
+    "-f")
+        echo "Fast-Build active, ROS workspace will not be re-built!"
+        UROS_FAST_BUILD=on
+        shift
+        ;;
+      "-v")
+        echo "Building in verbose mode"
+        UROS_VERBOSE_BUILD=on
+        shift
+        ;;
+  esac
+done
+
 export UROS_FAST_BUILD
+export UROS_VERBOSE_BUILD
 
 # Checking if firmware exists
 if [ -d $FW_TARGETDIR ]; then


### PR DESCRIPTION
Currently, the CMAKE_VERBOSE_MAKEFILE=ON setting in the zephyr build step creates a huge amount of build output. For most use-cases this provides very little additional information while obfuscating and hiding warnings and errors from own code.

This commit only introduces this flag and implements it for the zephyr rtos, but it can obviously later get used by other RTOS build scripts.