### PR TITLE
Test new rcutils and rcl repos 

### DIFF
--- a/config/freertos/crazyflie21/client_uros_packages.repos
+++ b/config/freertos/crazyflie21/client_uros_packages.repos
@@ -13,7 +13,7 @@ repositories:
   uros/rcl:
     type: git
     url: https://github.com/micro-ROS/rcl
-    version: foxy
+    version: feature/foxy_upgrade_04112020
   uros/rclc:
     type: git
     url: https://github.com/micro-ROS/rclc
@@ -21,7 +21,7 @@ repositories:
   uros/rcutils:
     type: git
     url: https://github.com/micro-ROS/rcutils
-    version: foxy
+    version: feature/foxy_upgrade_04112020
   uros/rmw_microxrcedds:
     type: git
     url: https://github.com/micro-ROS/rmw-microxrcedds.git
@@ -29,7 +29,7 @@ repositories:
   uros/rosidl_typesupport:
     type: git
     url: https://github.com/micro-ROS/rosidl_typesupport.git
-    version: foxy
+    version: feature/foxy_upgrade_04112020
   uros/rosidl_typesupport_microxrcedds:
     type: git
     url: https://github.com/micro-ROS/rosidl_typesupport_microxrcedds.git

--- a/config/freertos/esp32/client_uros_packages.repos
+++ b/config/freertos/esp32/client_uros_packages.repos
@@ -13,7 +13,7 @@ repositories:
   uros/rcl:
     type: git
     url: https://github.com/micro-ROS/rcl
-    version: foxy
+    version: feature/foxy_upgrade_04112020
   uros/rclc:
     type: git
     url: https://github.com/micro-ROS/rclc
@@ -21,7 +21,7 @@ repositories:
   uros/rcutils:
     type: git
     url: https://github.com/micro-ROS/rcutils
-    version: foxy
+    version: feature/foxy_upgrade_04112020
   uros/rmw_microxrcedds:
     type: git
     url: https://github.com/micro-ROS/rmw-microxrcedds.git
@@ -29,7 +29,7 @@ repositories:
   uros/rosidl_typesupport:
     type: git
     url: https://github.com/micro-ROS/rosidl_typesupport.git
-    version: foxy
+    version: feature/foxy_upgrade_04112020
   uros/rosidl_typesupport_microxrcedds:
     type: git
     url: https://github.com/micro-ROS/rosidl_typesupport_microxrcedds.git

--- a/config/freertos/nucleo_f446ze/client_uros_packages.repos
+++ b/config/freertos/nucleo_f446ze/client_uros_packages.repos
@@ -13,7 +13,7 @@ repositories:
   uros/rcl:
     type: git
     url: https://github.com/micro-ROS/rcl
-    version: foxy
+    version: feature/foxy_upgrade_04112020
   uros/rclc:
     type: git
     url: https://github.com/micro-ROS/rclc
@@ -21,7 +21,7 @@ repositories:
   uros/rcutils:
     type: git
     url: https://github.com/micro-ROS/rcutils
-    version: foxy
+    version: feature/foxy_upgrade_04112020
   uros/rmw_microxrcedds:
     type: git
     url: https://github.com/micro-ROS/rmw-microxrcedds.git
@@ -29,7 +29,7 @@ repositories:
   uros/rosidl_typesupport:
     type: git
     url: https://github.com/micro-ROS/rosidl_typesupport.git
-    version: foxy
+    version: feature/foxy_upgrade_04112020
   uros/rosidl_typesupport_microxrcedds:
     type: git
     url: https://github.com/micro-ROS/rosidl_typesupport_microxrcedds.git

--- a/config/freertos/nucleo_f746zg/client_uros_packages.repos
+++ b/config/freertos/nucleo_f746zg/client_uros_packages.repos
@@ -13,7 +13,7 @@ repositories:
   uros/rcl:
     type: git
     url: https://github.com/micro-ROS/rcl
-    version: foxy
+    version: feature/foxy_upgrade_04112020
   uros/rclc:
     type: git
     url: https://github.com/micro-ROS/rclc
@@ -21,7 +21,7 @@ repositories:
   uros/rcutils:
     type: git
     url: https://github.com/micro-ROS/rcutils
-    version: foxy
+    version: feature/foxy_upgrade_04112020
   uros/rmw_microxrcedds:
     type: git
     url: https://github.com/micro-ROS/rmw-microxrcedds.git
@@ -29,7 +29,7 @@ repositories:
   uros/rosidl_typesupport:
     type: git
     url: https://github.com/micro-ROS/rosidl_typesupport.git
-    version: foxy
+    version: feature/foxy_upgrade_04112020
   uros/rosidl_typesupport_microxrcedds:
     type: git
     url: https://github.com/micro-ROS/rosidl_typesupport_microxrcedds.git

--- a/config/freertos/olimex-stm32-e407/client_uros_packages.repos
+++ b/config/freertos/olimex-stm32-e407/client_uros_packages.repos
@@ -13,7 +13,7 @@ repositories:
   uros/rcl:
     type: git
     url: https://github.com/micro-ROS/rcl
-    version: foxy
+    version: feature/foxy_upgrade_04112020
   uros/rclc:
     type: git
     url: https://github.com/micro-ROS/rclc
@@ -21,7 +21,7 @@ repositories:
   uros/rcutils:
     type: git
     url: https://github.com/micro-ROS/rcutils
-    version: foxy
+    version: feature/foxy_upgrade_04112020
   uros/rmw_microxrcedds:
     type: git
     url: https://github.com/micro-ROS/rmw-microxrcedds.git
@@ -29,7 +29,7 @@ repositories:
   uros/rosidl_typesupport:
     type: git
     url: https://github.com/micro-ROS/rosidl_typesupport.git
-    version: foxy
+    version: feature/foxy_upgrade_04112020
   uros/rosidl_typesupport_microxrcedds:
     type: git
     url: https://github.com/micro-ROS/rosidl_typesupport_microxrcedds.git

--- a/config/generate_lib/generic/client_uros_packages.repos
+++ b/config/generate_lib/generic/client_uros_packages.repos
@@ -13,7 +13,7 @@ repositories:
   uros/rcl:
     type: git
     url: https://github.com/micro-ROS/rcl
-    version: foxy
+    version: feature/foxy_upgrade_04112020
   uros/rclc:
     type: git
     url: https://github.com/micro-ROS/rclc
@@ -25,7 +25,7 @@ repositories:
   uros/rcutils:
     type: git
     url: https://github.com/micro-ROS/rcutils
-    version: foxy
+    version: feature/foxy_upgrade_04112020
   uros/rmw_microxrcedds:
     type: git
     url: https://github.com/micro-ROS/rmw-microxrcedds.git
@@ -33,7 +33,7 @@ repositories:
   uros/rosidl_typesupport:
     type: git
     url: https://github.com/micro-ROS/rosidl_typesupport.git
-    version: foxy
+    version: feature/foxy_upgrade_04112020
   uros/rosidl_typesupport_microxrcedds:
     type: git
     url: https://github.com/micro-ROS/rosidl_typesupport_microxrcedds.git

--- a/config/nuttx/generic/client_uros_packages.repos
+++ b/config/nuttx/generic/client_uros_packages.repos
@@ -37,7 +37,7 @@ repositories:
   uros/rosidl_typesupport:
     type: git
     url: https://github.com/micro-ROS/rosidl_typesupport.git
-    version: foxy
+    version: feature/foxy_upgrade_04112020
   uros/rosidl_typesupport_microxrcedds:
     type: git
     url: https://github.com/micro-ROS/rosidl_typesupport_microxrcedds.git

--- a/config/zephyr/generic/client_uros_packages.repos
+++ b/config/zephyr/generic/client_uros_packages.repos
@@ -13,7 +13,7 @@ repositories:
   uros/rcl:
     type: git
     url: https://github.com/micro-ROS/rcl
-    version: foxy
+    version: feature/foxy_upgrade_04112020
   uros/rclc:
     type: git
     url: https://github.com/micro-ROS/rclc
@@ -25,7 +25,7 @@ repositories:
   uros/rcutils:
     type: git
     url: https://github.com/micro-ROS/rcutils
-    version: foxy
+    version: feature/foxy_upgrade_04112020
   uros/rmw_microxrcedds:
     type: git
     url: https://github.com/micro-ROS/rmw-microxrcedds.git
@@ -33,7 +33,7 @@ repositories:
   uros/rosidl_typesupport:
     type: git
     url: https://github.com/micro-ROS/rosidl_typesupport.git
-    version: foxy
+    version: feature/foxy_upgrade_04112020
   uros/rosidl_typesupport_microxrcedds:
     type: git
     url: https://github.com/micro-ROS/rosidl_typesupport_microxrcedds.git


### PR DESCRIPTION
This PR test CI for new branches of RCUtils and RCL rebased to ROS 2 branches on 04/11/2020