### PR TITLE
Added UUID to micro-ROS host

### DIFF
--- a/config/host/generic/client_host_packages.repos
+++ b/config/host/generic/client_host_packages.repos
@@ -43,3 +43,8 @@ repositories:
     type: git
     url: https://github.com/ros2/rcl_interfaces
     version: foxy
+
+  ros2/unique_identifier_msgs:
+    type: git
+    url: https://github.com/ros2/unique_identifier_msgs
+    version: foxy


### PR DESCRIPTION
This PR add UUID packages to micro-ROS host in order to work with ROS 2 actions