### PR TITLE
Improve flash step for zephyr RTOS

### DIFF
--- a/config/zephyr/generic/flash.sh
+++ b/config/zephyr/generic/flash.sh
@@ -21,8 +21,48 @@ else
 
 
 
-    # Choose flash method based on board
-    if [ "$PLATFORM" = "discovery_l475_iot1" ] || [ "$PLATFORM" = "nucleo_f401re" ]; then
+    # These boards need special openocd rules
+    FLASH_OPENOCD=false
+    if [ "$PLATFORM" = "olimex-stm32-e407" ]; then
+
+        FLASH_OPENOCD=true
+        OPENOCD_TARGET="stm32f4x.cfg"
+        if lsusb -d 15BA:002a; then
+            OPENOCD_PROGRAMMER=interface/ftdi/olimex-arm-usb-tiny-h.cfg
+        elif lsusb -d 15BA:0003;then
+            OPENOCD_PROGRAMMER=interface/ftdi/olimex-arm-usb-ocd.cfg
+        elif lsusb -d 15BA:002b;then
+            OPENOCD_PROGRAMMER=interface/ftdi/olimex-arm-usb-ocd-h.cfg
+        else
+            echo "Error: Unsuported OpenOCD USB programmer"
+            exit 1
+        fi
+
+    elif [ "$PLATFORM" = "nucleo_h743zi" ]; then
+
+        FLASH_OPENOCD=true
+        OPENOCD_TARGET="stm32h7x.cfg"
+
+        if lsusb -d 0483:374e;then
+            OPENOCD_PROGRAMMER=interface/stlink.cfg
+        else
+            echo "Error: Unsupported OpenOCD programmer"
+            exit 1
+        fi
+
+    fi
+
+
+
+    if [ "$FLASH_OPENOCD" = true ]; then
+
+        openocd -f $OPENOCD_PROGRAMMER -f target/$OPENOCD_TARGET \
+                -c init \
+                -c "reset halt" \
+                -c "flash write_image erase $ZEPHYR_BUILD_DIR/zephyr.bin 0x08000000" \
+                -c "reset run; exit"
+
+    elif [ "$PLATFORM" = "discovery_l475_iot1" ] || [ "$PLATFORM" = "nucleo_f401re" ]; then
 
         export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
         export ZEPHYR_SDK_INSTALL_DIR=$FW_TARGETDIR/zephyr-sdk
@@ -32,33 +72,6 @@ else
         export PATH=~/.local/bin:"$PATH"
 
         west flash
-
-    elif [ "$PLATFORM" = "olimex-stm32-e407" ]; then
-
-        if lsusb -d 15BA:002a; then
-            PROGRAMMER=interface/ftdi/olimex-arm-usb-tiny-h.cfg
-        elif lsusb -d 15BA:0003;then
-            PROGRAMMER=interface/ftdi/olimex-arm-usb-ocd.cfg
-        elif lsusb -d 15BA:002b;then
-            PROGRAMMER=interface/ftdi/olimex-arm-usb-ocd-h.cfg
-        else
-            echo "Error: Unsuported OpenOCD USB programmer"
-            exit 1
-        fi
-
-        openocd -f $PROGRAMMER -f target/stm32f4x.cfg -c init -c "reset halt" -c "flash write_image erase build/zephyr/zephyr.bin 0x08000000" -c "reset" -c "exit"
-
-    elif [ "$PLATFORM" = "nucleo_h743zi" ]; then
-
-        if lsusb -d 0483:374e;then
-            PROGRAMMER=interface/stlink.cfg
-            TARGET=stm32h7x.cfg
-        else
-            echo "Error: Unsupported OpenOCD programmer"
-            exit 1
-        fi
-
-        openocd -f $PROGRAMMER -f target/$TARGET -c init -c "reset halt" -c "flash write_image erase build/zephyr/zephyr.bin 0x08000000" -c "reset run; exit"
 
     else
 

--- a/config/zephyr/generic/flash.sh
+++ b/config/zephyr/generic/flash.sh
@@ -62,21 +62,15 @@ else
                 -c "flash write_image erase $ZEPHYR_BUILD_DIR/zephyr.bin 0x08000000" \
                 -c "reset run; exit"
 
-    elif [ "$PLATFORM" = "discovery_l475_iot1" ] || [ "$PLATFORM" = "nucleo_f401re" ]; then
+    else
 
         export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
         export ZEPHYR_SDK_INSTALL_DIR=$FW_TARGETDIR/zephyr-sdk
+        export PATH=~/.local/bin:"$PATH"
 
         source $FW_TARGETDIR/zephyrproject/zephyr/zephyr-env.sh
 
-        export PATH=~/.local/bin:"$PATH"
-
         west flash
-
-    else
-
-        echo "Unrecognized board: $PLATFORM"
-        exit 1
 
     fi
 

--- a/config/zephyr/generic/flash.sh
+++ b/config/zephyr/generic/flash.sh
@@ -1,48 +1,72 @@
 pushd $FW_TARGETDIR > /dev/null
 
-if [ "$PLATFORM" = "discovery_l475_iot1" ] || [ "$PLATFORM" = "nucleo_f401re" ]; then
-  export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
-  export ZEPHYR_SDK_INSTALL_DIR=$FW_TARGETDIR/zephyr-sdk
+ZEPHYR_BUILD_DIR="$FW_TARGETDIR/build/zephyr"
 
-  source $FW_TARGETDIR/zephyrproject/zephyr/zephyr-env.sh
+# Host platform (=native_posix) is special, as flashing is actually just executing the binary
+if [ "$PLATFORM" = "host" ]; then
 
-  export PATH=~/.local/bin:"$PATH"
-
-  west flash
-elif [ "$PLATFORM" = "olimex-stm32-e407" ]; then
-  if [ -f build/zephyr/zephyr.bin ]; then
-    echo "Flashing firmware for $RTOS platform $PLATFORM"
-
-      if lsusb -d 15BA:002a; then
-        PROGRAMMER=interface/ftdi/olimex-arm-usb-tiny-h.cfg
-      elif lsusb -d 15BA:0003;then
-        PROGRAMMER=interface/ftdi/olimex-arm-usb-ocd.cfg
-      elif lsusb -d 15BA:002b;then
-        PROGRAMMER=interface/ftdi/olimex-arm-usb-ocd-h.cfg
-      else
-        echo "Error. Unsuported OpenOCD USB programmer"
+    if [ ! -f "$ZEPHYR_BUILD_DIR/zephyr.exe" ]; then
+        echo "Error: $ZEPHYR_BUILD_DIR/zephyr.exe not found. Please compile before flashing."
         exit 1
-      fi
-
-      openocd -f $PROGRAMMER -f target/stm32f4x.cfg -c init -c "reset halt" -c "flash write_image erase build/zephyr/zephyr.bin 0x08000000" -c "reset" -c "exit"
-
-  elif [ "$PLATFORM" = "nucleo_h743zi" ]; then
-    if lsusb -d 0483:374e;then
-        PROGRAMMER=interface/stlink.cfg
-        TARGET=stm32h7x.cfg
     fi
 
-    openocd -f $PROGRAMMER -f target/$TARGET -c init -c "reset halt" -c "flash write_image erase build/zephyr/zephyr.bin 0x08000000" -c "reset run; exit"
+    $ZEPHYR_BUILD_DIR/zephyr.exe
 
-  else
-    echo "build/zephyr/zephyr.bin not found: please compile before flashing."
-  fi
-elif [ "$PLATFORM" = "host" ]; then
-  ./build/zephyr/zephyr.exe 
 else
-  echo "Unrecognized board: $PLATFORM"
-  exit 1
+
+    if [ ! -f "$ZEPHYR_BUILD_DIR/zephyr.bin" ]; then
+        echo "Error: $ZEPHYR_BUILD_DIR/zephyr.bin not found. Please compile before flashing."
+        exit 1
+    fi
+
+
+
+    # Choose flash method based on board
+    if [ "$PLATFORM" = "discovery_l475_iot1" ] || [ "$PLATFORM" = "nucleo_f401re" ]; then
+
+        export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
+        export ZEPHYR_SDK_INSTALL_DIR=$FW_TARGETDIR/zephyr-sdk
+
+        source $FW_TARGETDIR/zephyrproject/zephyr/zephyr-env.sh
+
+        export PATH=~/.local/bin:"$PATH"
+
+        west flash
+
+    elif [ "$PLATFORM" = "olimex-stm32-e407" ]; then
+
+        if lsusb -d 15BA:002a; then
+            PROGRAMMER=interface/ftdi/olimex-arm-usb-tiny-h.cfg
+        elif lsusb -d 15BA:0003;then
+            PROGRAMMER=interface/ftdi/olimex-arm-usb-ocd.cfg
+        elif lsusb -d 15BA:002b;then
+            PROGRAMMER=interface/ftdi/olimex-arm-usb-ocd-h.cfg
+        else
+            echo "Error: Unsuported OpenOCD USB programmer"
+            exit 1
+        fi
+
+        openocd -f $PROGRAMMER -f target/stm32f4x.cfg -c init -c "reset halt" -c "flash write_image erase build/zephyr/zephyr.bin 0x08000000" -c "reset" -c "exit"
+
+    elif [ "$PLATFORM" = "nucleo_h743zi" ]; then
+
+        if lsusb -d 0483:374e;then
+            PROGRAMMER=interface/stlink.cfg
+            TARGET=stm32h7x.cfg
+        else
+            echo "Error: Unsupported OpenOCD programmer"
+            exit 1
+        fi
+
+        openocd -f $PROGRAMMER -f target/$TARGET -c init -c "reset halt" -c "flash write_image erase build/zephyr/zephyr.bin 0x08000000" -c "reset run; exit"
+
+    else
+
+        echo "Unrecognized board: $PLATFORM"
+        exit 1
+
+    fi
+
 fi
 
 popd > /dev/null
-


### PR DESCRIPTION
This pr contains some cleanups and minor behavior changes which should make using and evolving the flash step in zephyr easier. The behavior changes are:
- The nucleo_h743zi platform should now work again, it seems there was a faulty indentation in the previous version.
- All platforms now check if the used build artifact (```zephyr.exe```/```zephyr.bin```) exists before using it.
- Console output should now be consistent between the platforms (obviously excluding the flash tool).
- The ```olimex-stm32-e407``` platform now runs the flashed firmware after resetting. This is consistent with what the ```west flash```-based platforms and the ```nucleo_h743zi``` platform do.
- The step now defaults to using ```west flash``` as opposed to special casing each and every supported platform. This seems reasonable to me, as this should be the correct way for most zephyr-based use cases.

As a side effect, this should allow the usage of any suitable zephyr-supported target by just adding its name to the supported_platforms file, as ```flash.sh``` will no longer complain about an unknown platform.

It would be nice if somebody could check that i didn't break anything for the openocd-based boards, as i don't have access to any of them (i could just check that the command actually tried doing something which seemed useful for them).