### PR TITLE
Improve build_agent.sh script

### DIFF
--- a/scripts/build_agent.sh
+++ b/scripts/build_agent.sh
@@ -6,7 +6,7 @@ set -o pipefail
 
 echo "Building micro-ROS Agent"
 
-colcon build --packages-select micro_ros_agent microxrcedds_agent drive_base_msgs $@ --cmake-args \
+colcon build --packages-up-to micro_ros_agent $@ --cmake-args \
     "-DUAGENT_BUILD_EXECUTABLE=OFF" \
     "-DUAGENT_P2P_PROFILE=OFF" \
     "--no-warn-unused-cli"


### PR DESCRIPTION
This change avoids the necessity of including every new required package into the colcon `packages-select` list. Instead, we let colcon take care of the required dependencies to build the `micro_ros_agent` target.