### PR TITLE
bump zephyr version to 2.6.0; zephyr-sdk version to 0.12.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,11 @@ This package is the **official build system for micro-ROS**. It provides tools a
 | [FreeRTOS](https://www.freertos.org/)    | [ST Nucleo F767ZI](https://www.st.com/en/evaluation-tools/nucleo-f746zg.html)  <sup>1</sup>          | STM32CubeMX latest   | `freertos nucleo_f767zi`     |
 | [FreeRTOS](https://www.freertos.org/)    | [Espressif ESP32](https://www.espressif.com/en/products/socs/esp32/overview)                         | v8.2.0               | `freertos esp32`             |
 | [FreeRTOS](https://www.freertos.org/)    | [Crazyflie 2.1](https://www.bitcraze.io/crazyflie-2-1/)                                              | v10.2.1 - CF 2020.06 | `freertos crazyflie21`       |
-| [Zephyr](https://www.zephyrproject.org/) | [Olimex STM32-E407](https://www.olimex.com/Products/ARM/ST/STM32-E407/open-source-hardware)          | v2.4.99              | `zephyr olimex-stm32-e407`   |
-| [Zephyr](https://www.zephyrproject.org/) | [ST B-L475E-IOT01A](https://docs.zephyrproject.org/latest/boards/arm/disco_l475_iot1/doc/index.html) | v2.4.99              | `zephyr discovery_l475_iot1` |
-| [Zephyr](https://www.zephyrproject.org/) | [ST Nucleo H743ZI](https://www.st.com/en/evaluation-tools/nucleo-h743zi.html) <sup>1</sup>           | v2.4.99              | `zephyr nucleo_h743zi`       |
-| [Zephyr](https://www.zephyrproject.org/) | [Zephyr emulator](https://docs.zephyrproject.org/2.3.0/boards/posix/native_posix/doc/index.html)     | v2.4.99              | `zephyr host`                |
+| [Zephyr](https://www.zephyrproject.org/) | [Olimex STM32-E407](https://www.olimex.com/Products/ARM/ST/STM32-E407/open-source-hardware)          | v2.6.0               | `zephyr olimex-stm32-e407`   |
+| [Zephyr](https://www.zephyrproject.org/) | [ST Nucleo F446RE](https://www.st.com/en/evaluation-tools/nucleo-f446re.html)  <sup>1</sup>          | v2.6.0               | `zephyr nucleo_f446re`       |
+| [Zephyr](https://www.zephyrproject.org/) | [ST B-L475E-IOT01A](https://docs.zephyrproject.org/latest/boards/arm/disco_l475_iot1/doc/index.html) | v2.6.0               | `zephyr discovery_l475_iot1` |
+| [Zephyr](https://www.zephyrproject.org/) | [ST Nucleo H743ZI](https://www.st.com/en/evaluation-tools/nucleo-h743zi.html) <sup>1</sup>           | v2.6.0               | `zephyr nucleo_h743zi`       |
+| [Zephyr](https://www.zephyrproject.org/) | [Zephyr emulator](https://docs.zephyrproject.org/2.3.0/boards/posix/native_posix/doc/index.html)     | v2.6.0               | `zephyr host`                |
 | [Mbed](https://os.mbed.com/)             | [ST B-L475E-IOT01A](https://os.mbed.com/platforms/ST-Discovery-L475E-IOT01A/)                        | v6.6                 | `mbed disco_l475vg_iot01a`   |
 | -                                        | Static library (.a) and headers (.h) <sup>3</sup>                                                    | -                    | `generate_lib`               |
 | Linux                                    | *Host <sup>2</sup>*                                                                                  | Ubuntu 18.04/20.04   | `host`                       |
@@ -131,7 +132,7 @@ In summary, the supported configurations for transports are:
 | ST B-L475E-IOT01A             |         -         | USB, UART, Network |        UART        |
 | Crazyflie 2.1                 | Custom Radio Link |         -          |         -          |
 | Espressif ESP32               |  UART, WiFI UDP   |         -          |         -          |
-| ST Nucleo F446RE <sup>1</sup> |       UART        |         -          |         -          |
+| ST Nucleo F446RE <sup>1</sup> |       UART        |        UART        |         -          |
 | ST Nucleo F446ZE <sup>1</sup> |       UART        |         -          |         -          |
 | ST Nucleo H743ZI <sup>1</sup> |         -         |        UART        |         -          |
 | ST Nucleo F746ZG <sup>1</sup> |       UART        |        UART        |         -          |

--- a/config/zephyr/generic/create.sh
+++ b/config/zephyr/generic/create.sh
@@ -21,7 +21,7 @@ pushd $FW_TARGETDIR >/dev/null
     west init zephyrproject
     pushd zephyrproject >/dev/null
         cd zephyr
-          git checkout zephyr-v2.5.0
+          git checkout zephyr-v2.6.0
         cd ..
         west update
     popd >/dev/null
@@ -29,12 +29,12 @@ pushd $FW_TARGETDIR >/dev/null
     pip3 install -r zephyrproject/zephyr/scripts/requirements.txt
 
     if [ "$PLATFORM" = "host" ]; then
-        export TOOLCHAIN_VERSION=zephyr-sdk-0.11.2-setup.run
+        export TOOLCHAIN_VERSION=zephyr-sdk-0.12.4-x86_64-linux-setup.run
     else
-        export TOOLCHAIN_VERSION=zephyr-toolchain-arm-0.11.2-setup.run
+        export TOOLCHAIN_VERSION=zephyr-toolchain-arm-0.12.4-x86_64-linux-setup.run
     fi
 
-    wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.11.2/$TOOLCHAIN_VERSION
+    wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.12.4/$TOOLCHAIN_VERSION
     chmod +x $TOOLCHAIN_VERSION
     ./$TOOLCHAIN_VERSION -- -d $(pwd)/zephyr-sdk -y
 


### PR DESCRIPTION
The previous zephyr-sdk version 0.11.2 installed by micro_ros_setup contained no cmake files and it relied to be found via the home directory. That's not necessary with 0.12.4 anymore and the zephyr-sdk downloaded by micro_ros_setup works standalone.

I also bumped zephyrs version to 2.6.0 as it contains some better board dts. In my case I made a full CAN bus app work on the nucleo f446re with microros support.