### PR TITLE
Support for flashing Olimex STM32-E407 with STLINK v2 debuggers

### DIFF
--- a/config/freertos/olimex-stm32-e407/flash.sh
+++ b/config/freertos/olimex-stm32-e407/flash.sh
@@ -11,6 +11,10 @@ pushd $OLIMEX_EXTENSIONS_DIR > /dev/null
         PROGRAMMER=interface/ftdi/olimex-arm-usb-ocd.cfg
       elif lsusb -d 15BA:002b;then
         PROGRAMMER=interface/ftdi/olimex-arm-usb-ocd-h.cfg
+      elif lsusb -d 0483:374b; then
+        PROGRAMMER=interface/stlink-v2-1.cfg
+      elif lsusb -d 0483:3748; then
+        PROGRAMMER=interface/stlink-v2.cfg
       else
         echo "Error. Unsuported OpenOCD USB programmer"
         exit 1


### PR DESCRIPTION
The STLINK v2 debuggers can be used to flash the Olimex STM32-E407 board, and in fact that is what we use at SpaceRyde. Added support for them in the flash.sh script. This is not a foxy-specific change per se, but that is the ROS distribution we are currently using. If there is a nice way to include this change in galactic and main as well, let me know.