### PR TITLE
Fix: Use $FW_TARGETDIR/ instead of firmware/

### DIFF
--- a/scripts/build_firmware.sh
+++ b/scripts/build_firmware.sh
@@ -47,9 +47,9 @@ export UROS_EXTRA_BUILD_ARGS
 # Checking if firmware exists
 if [ -d $FW_TARGETDIR ]; then
     RTOS=$(head -n1 $FW_TARGETDIR/PLATFORM)
-    PLATFORM=$(head -n2 firmware/PLATFORM | tail -n1)
+    PLATFORM=$(head -n2 $FW_TARGETDIR/PLATFORM | tail -n1)
     if [ -f $FW_TARGETDIR/TRANSPORT ]; then
-        TRANSPORT=$(head -n1 firmware/TRANSPORT)
+        TRANSPORT=$(head -n1 $FW_TARGETDIR/TRANSPORT)
     fi
 else
     echo "Firmware folder not found. Please use ros2 run micro_ros_setup create_firmware_ws.sh to create a new project."

--- a/scripts/configure_firmware.sh
+++ b/scripts/configure_firmware.sh
@@ -10,7 +10,7 @@ export PREFIX=$(ros2 pkg prefix micro_ros_setup)
 # Checking if firmware exists
 if [ -d $FW_TARGETDIR ]; then
     RTOS=$(head -n1 $FW_TARGETDIR/PLATFORM)
-    PLATFORM=$(head -n2 firmware/PLATFORM | tail -n1)
+    PLATFORM=$(head -n2 $FW_TARGETDIR/PLATFORM | tail -n1)
 else
     echo "Firmware folder not found. Please use ros2 run micro_ros_setup create_firmware_ws.sh to create a new project."
     exit 1

--- a/scripts/flash_firmware.sh
+++ b/scripts/flash_firmware.sh
@@ -10,7 +10,7 @@ PREFIX=$(ros2 pkg prefix micro_ros_setup)
 # Checking if firmware exists
 if [ -d $FW_TARGETDIR ]; then
     RTOS=$(head -n1 $FW_TARGETDIR/PLATFORM)
-    PLATFORM=$(head -n2 firmware/PLATFORM | tail -n1)
+    PLATFORM=$(head -n2 $FW_TARGETDIR/PLATFORM | tail -n1)
 else
     echo "Firmware folder not found. Please use ros2 run micro_ros_setup create_firmware_ws.sh to create a new project."
     exit 1


### PR DESCRIPTION
In some places, the path to firmware is hardcoded instead of using the FW_TARGETDIR variable. This PR fixes it.