### PR TITLE
Build dynamic lib of rosidl_typesupport _microxrcedds

### DIFF
--- a/config/host/generic/build.sh
+++ b/config/host/generic/build.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-colcon build --packages-up-to rosidl_typesupport_microxrcedds_c --metas src --cmake-args -DBUILD_TESTING=OFF $@
-colcon build --packages-up-to rosidl_typesupport_microxrcedds_cpp --metas src --cmake-args -DBUILD_TESTING=OFF $@
+colcon build --packages-up-to rosidl_typesupport_microxrcedds_c --metas src --cmake-args -DBUILD_TESTING=OFF -DBUILD_SHARED_LIBS=ON $@
+colcon build --packages-up-to rosidl_typesupport_microxrcedds_cpp --metas src --cmake-args -DBUILD_TESTING=OFF -DBUILD_SHARED_LIBS=ON $@
 
 set +o nounset
 . install/local_setup.bash
 set -o nounset
 
-colcon build --metas src --cmake-args -DBUILD_TESTING=OFF $@
+colcon build --metas src --cmake-args -DBUILD_TESTING=OFF -DBUILD_SHARED_LIBS=ON $@

--- a/config/host/generic/client_host_packages.repos
+++ b/config/host/generic/client_host_packages.repos
@@ -33,7 +33,6 @@ repositories:
   uros/micro_ros_utilities:
     type: git
     url: https://github.com/micro-ROS/micro_ros_utilities
-    version: main
     version: galactic
 
 # Required messages packages


### PR DESCRIPTION
- change build.sh to make sure to build libstd_msgs__rosidl_typesupport_microxrcedds_c.so and libstd_msgs__rosidl_typesupport_microxrcedds_cpp.so
- fix a typo in colcon.meta