### PR TITLE
Modified zephyr create.sh to pull correct toolchain based on arch

### DIFF
--- a/config/zephyr/generic/create.sh
+++ b/config/zephyr/generic/create.sh
@@ -15,6 +15,8 @@ if ! (( $CMAKE_VERSION_MAJOR_NUMBER > 3 || \
 fi
 
 export PATH=~/.local/bin:"$PATH"
+export ZEPHYR_VERSION="v0.12.4"
+export ARCH=$(uname -m)
 
 pushd $FW_TARGETDIR >/dev/null
 
@@ -29,12 +31,22 @@ pushd $FW_TARGETDIR >/dev/null
     pip3 install -r zephyrproject/zephyr/scripts/requirements.txt
 
     if [ "$PLATFORM" = "host" ]; then
-        export TOOLCHAIN_VERSION=zephyr-sdk-0.12.4-x86_64-linux-setup.run
+        if [ "$ARCH" = "aarch64" ]; then
+            export TOOLCHAIN_VERSION=zephyr-sdk-0.13.1-linux-aarch64-setup.run
+            export ZEPHYR_VERSION="v0.13.1"
+        else
+            export TOOLCHAIN_VERSION=zephyr-sdk-0.12.4-x86_64-linux-setup.run
+        fi
     else
-        export TOOLCHAIN_VERSION=zephyr-toolchain-arm-0.12.4-x86_64-linux-setup.run
+        if [ "$ARCH" = "aarch64" ]; then
+            export TOOLCHAIN_VERSION=zephyr-toolchain-arm-0.13.1-linux-aarch64-setup.run
+            export ZEPHYR_VERSION="v0.13.1"
+        else
+            export TOOLCHAIN_VERSION=zephyr-toolchain-arm-0.12.4-x86_64-linux-setup.run
+        fi
     fi
 
-    wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.12.4/$TOOLCHAIN_VERSION
+    wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/$ZEPHYR_VERSION/$TOOLCHAIN_VERSION
     chmod +x $TOOLCHAIN_VERSION
     ./$TOOLCHAIN_VERSION -- -d $(pwd)/zephyr-sdk -y
 


### PR DESCRIPTION
Currently the create.sh script only pulls down an x86 version of zephyr regardless of the arch of the system the user is building on.
We have a few people that are using M1 macbooks with Ubuntu VMs and this has been causing a bit of trouble since the workspace never gets setup correctly with the right toolchain.

Currently just for galactic but I can make another PR for other versions if necessary

Proposed fix: Read the arch of the system and pull down the aarch64 version if necessary. 
Using v0.13.1 for arm as that's what was recommended to me