### PR TITLE
Switch to ar M-script to build libmicroros.a

### DIFF
--- a/config/generate_lib/generic/build.sh
+++ b/config/generate_lib/generic/build.sh
@@ -22,7 +22,7 @@ BUILD_DIR=$FW_TARGETDIR/build
 pushd $FW_TARGETDIR/mcu_ws >/dev/null
 
 	rm -rf build install log
-	
+
 	colcon build \
 		--merge-install \
 		--packages-ignore-regex=.*_cpp \

--- a/config/generate_lib/generic/build.sh
+++ b/config/generate_lib/generic/build.sh
@@ -1,18 +1,18 @@
 . $PREFIX/config/utils.sh
 
 if [ $# -ge 1 ]; then
-    TOOLCHAIN=$1
+	TOOLCHAIN=$1
 else
-    echo "Syntax: ros2 run micro_ros_setup build_firmware.sh <CMake toolchain file> [Colcon meta file]"
-    exit 1
+	echo "Syntax: ros2 run micro_ros_setup build_firmware.sh <CMake toolchain file> [Colcon meta file]"
+	exit 1
 fi
 
 if [ $# -ge 2 ]; then
-    COLCON_META=$2
+	COLCON_META=$2
 	echo "Using provided meta: $COLCON_META"
 
 else
-    COLCON_META=$FW_TARGETDIR/mcu_ws/colcon.meta
+	COLCON_META=$FW_TARGETDIR/mcu_ws/colcon.meta
 	echo "Using default meta: $COLCON_META"
 fi
 
@@ -23,7 +23,7 @@ pushd $FW_TARGETDIR/mcu_ws >/dev/null
 
 	rm -rf build install log
 	
-   	colcon build \
+	colcon build \
 		--merge-install \
 		--packages-ignore-regex=.*_cpp \
 		--metas $COLCON_META \
@@ -37,7 +37,7 @@ pushd $FW_TARGETDIR/mcu_ws >/dev/null
 		-DCMAKE_TOOLCHAIN_FILE=$TOOLCHAIN \
 		-DCMAKE_VERBOSE_MAKEFILE=ON; \
 
-    mkdir -p $FW_TARGETDIR/libmicroros; cd $FW_TARGETDIR/libmicroros; \
+	mkdir -p $FW_TARGETDIR/libmicroros; cd $FW_TARGETDIR/libmicroros; \
 	echo "CREATE libmicroros.a" > $FW_TARGETDIR/libmicroros/ar_script.m; \
 	for file in $(find "$FW_TARGETDIR/install/lib/" -name '*.a'); do \
 		echo "ADDLIB ${file}" >> $FW_TARGETDIR/libmicroros/ar_script.m; \
@@ -46,7 +46,7 @@ pushd $FW_TARGETDIR/mcu_ws >/dev/null
 	echo "END" >> $FW_TARGETDIR/libmicroros/ar_script.m; \
 	ar -M < $FW_TARGETDIR/libmicroros/ar_script.m; \
 	mkdir -p $BUILD_DIR; cp libmicroros.a $BUILD_DIR; \
-    cp -R $FW_TARGETDIR/mcu_ws/install/include $BUILD_DIR/; \
+	cp -R $FW_TARGETDIR/mcu_ws/install/include $BUILD_DIR/; \
 	cd ..; rm -rf libmicroros;
 
 popd >/dev/null

--- a/config/generate_lib/generic/build.sh
+++ b/config/generate_lib/generic/build.sh
@@ -45,7 +45,7 @@ pushd $FW_TARGETDIR/mcu_ws >/dev/null
 	echo "SAVE" >> $FW_TARGETDIR/libmicroros/ar_script.m; \
 	echo "END" >> $FW_TARGETDIR/libmicroros/ar_script.m; \
 	ar -M < $FW_TARGETDIR/libmicroros/ar_script.m; \
-	mkdir -p $BUILD_DIR; cp libmicroros.a $BUILD_DIR; ranlib $BUILD_DIR/libmicroros.a; \
+	mkdir -p $BUILD_DIR; cp libmicroros.a $BUILD_DIR; \
     cp -R $FW_TARGETDIR/mcu_ws/install/include $BUILD_DIR/; \
 	cd ..; rm -rf libmicroros;
 

--- a/config/generate_lib/generic/build.sh
+++ b/config/generate_lib/generic/build.sh
@@ -38,15 +38,14 @@ pushd $FW_TARGETDIR/mcu_ws >/dev/null
 		-DCMAKE_VERBOSE_MAKEFILE=ON; \
 
     mkdir -p $FW_TARGETDIR/libmicroros; cd $FW_TARGETDIR/libmicroros; \
-	for file in $(find $FW_TARGETDIR/mcu_ws/install/lib/ -name '*.a'); do \
-		folder=$(echo $file | sed -E "s/(.+)\/(.+).a/\2/"); \
-		mkdir -p $folder; cd $folder; ar x $file; \
-		for f in *; do \
-			mv $f ../$folder-$f; \
-		done; \
-		cd ..; rm -rf $folder; \
+	echo "CREATE libmicroros.a" > $FW_TARGETDIR/libmicroros/ar_script.m; \
+	for file in $(find "$FW_TARGETDIR/install/lib/" -name '*.a'); do \
+		echo "ADDLIB ${file}" >> $FW_TARGETDIR/libmicroros/ar_script.m; \
 	done ; \
-	ar rc libmicroros.a $(ls *.o *.obj 2> /dev/null); mkdir -p $BUILD_DIR; cp libmicroros.a $BUILD_DIR; ranlib $BUILD_DIR/libmicroros.a; \
+	echo "SAVE" >> $FW_TARGETDIR/libmicroros/ar_script.m; \
+	echo "END" >> $FW_TARGETDIR/libmicroros/ar_script.m; \
+	ar -M < $FW_TARGETDIR/libmicroros/ar_script.m; \
+	mkdir -p $BUILD_DIR; cp libmicroros.a $BUILD_DIR; ranlib $BUILD_DIR/libmicroros.a; \
     cp -R $FW_TARGETDIR/mcu_ws/install/include $BUILD_DIR/; \
 	cd ..; rm -rf libmicroros;
 


### PR DESCRIPTION
As per subject.

Bit of a wip as I can't test this myself right now, and have copied the changes from my development machine verbatim.

Last two commits are technically off-topic, I'd be OK with dropping them. Diff without them: [here](https://github.com/micro-ROS/micro_ros_setup/pull/574/files?w=1).

I'm uncertain about whether `ranlib` would still be needed, so 905f5081ba6a7386f67e2d20d5a9cd7cc53d4a59 removes it. If needed, that could easily be reverted.

This is for #564.
