### PR TITLE
Support Segger J-Link to flash Olimex E407

### DIFF
--- a/config/freertos/olimex-stm32-e407/flash.sh
+++ b/config/freertos/olimex-stm32-e407/flash.sh
@@ -15,6 +15,8 @@ pushd $OLIMEX_EXTENSIONS_DIR > /dev/null
         PROGRAMMER=interface/stlink-v2-1.cfg
       elif lsusb -d 0483:3748; then
         PROGRAMMER=interface/stlink-v2.cfg
+      elif lsusb -d 1366:0101 || lsusb -d 1366:0105; then
+        PROGRAMMER=interface/jlink.cfg
       else
         echo "Error. Unsuported OpenOCD USB programmer"
         exit 1
@@ -26,4 +28,5 @@ pushd $OLIMEX_EXTENSIONS_DIR > /dev/null
   fi
 
 popd > /dev/null
+
 


### PR DESCRIPTION
Added support for flashing an Olimex STM32-E407 using a Segger J-Link debugger. Tested using the [FreeRTOS tutorial](https://micro.ros.org/docs/tutorials/core/first_application_rtos/freertos/) on humble with a clone of a Segger J-Link V9. Although it should work fine in other distributions and with an original debugger.

![photo_5936108535442160756_y](https://user-images.githubusercontent.com/22426909/235216868-04f00c22-e145-4302-9339-ecd7da2be155.jpg)
