### PR TITLE
Remove non-header files from include folder

### DIFF
--- a/config/generate_lib/generic/build.sh
+++ b/config/generate_lib/generic/build.sh
@@ -48,6 +48,8 @@ pushd $FW_TARGETDIR/mcu_ws >/dev/null
 	done ; \
 	ar rc libmicroros.a $(ls *.o *.obj 2> /dev/null); mkdir -p $BUILD_DIR; cp libmicroros.a $BUILD_DIR; ranlib $BUILD_DIR/libmicroros.a; \
     cp -R $FW_TARGETDIR/mcu_ws/install/include $BUILD_DIR/; \
+    rm $(find $BUILD_DIR/include -type f -not -name "*.h" -not -name "*.hpp") \
+    rm -rf $(find $BUILD_DIR/include -type d -empty) \
 	cd ..; rm -rf libmicroros;
 
 popd >/dev/null


### PR DESCRIPTION
The `include` directory previously contained all files copied over, but only `*.h` and `*.hpp` files are required. This commit removes all files that do not have a `.h` or `.hpp` extension, as well as any empty directories that may result from this cleanup.