### PR TITLE
Fix Nightly (#719)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
             (test -f install/micro_ros_setup/lib/micro_ros_setup/build_firmware.sh) && true || false
 
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v4.4.0
         with:
           name: micro_ros_build_${{ inputs.ci_target_ref }}
           path: install
@@ -79,7 +79,7 @@ jobs:
           rosdep update --rosdistro ${{ env.ROS_DISTRO }}
           rosdep install --rosdistro ${{ env.ROS_DISTRO }} -y --from-paths src --ignore-src -y
 
-      - uses: actions/download-artifact@v1
+      - uses: actions/download-artifact@v4.1.7
         with:
           name: micro_ros_build_${{ inputs.ci_target_ref }}
           path: install
@@ -228,7 +228,7 @@ jobs:
           rosdep update --rosdistro ${{ env.ROS_DISTRO }}
           rosdep install --rosdistro ${{ env.ROS_DISTRO }} -y --from-paths src --ignore-src -y
 
-      - uses: actions/download-artifact@v1
+      - uses: actions/download-artifact@v4.1.7
         with:
           name: micro_ros_build_${{ inputs.ci_target_ref }}
           path: install


### PR DESCRIPTION
* Bump actions/download-artifact from 1 to 4.1.7 in /.github/workflows

Bumps [actions/download-artifact](https://github.com/actions/download-artifact) from 1 to 4.1.7.
- [Release notes](https://github.com/actions/download-artifact/releases)
- [Commits](https://github.com/actions/download-artifact/compare/v1...v4.1.7)

---
updated-dependencies:
- dependency-name: actions/download-artifact
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>

* Bump upload_artifact

Signed-off-by: Pablo Garrido <pablogs9@gmail.com>

---------

Signed-off-by: dependabot[bot] <support@github.com>
Signed-off-by: Pablo Garrido <pablogs9@gmail.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
(cherry picked from commit 32b25e573c624164d7f9f84e12f726d65568f90d)
