### PR TITLE
Sphinx dependency conflict fix

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -25,6 +25,8 @@ eProsima
     Jose Antonio Moral <joseantoniomoralparras@eprosima.com>
     Pablo Garrido <pablogarrido@eprosima.com>
 
+Jakob Friedl <friedl.jak@gmail.com>
+
 Robert Bosch GmbH
     Ingo Lütkebohle  <ingo.luetkebohle@de.bosch.com>
     Ralph Lange <ralph.lange@de.bosch.com>

--- a/config/zephyr/generic/create.sh
+++ b/config/zephyr/generic/create.sh
@@ -67,6 +67,6 @@ pushd $FW_TARGETDIR >/dev/null
     touch mcu_ws/uros/rclc/rclc_examples/COLCON_IGNORE
 
     # Upgrade sphinx
-    pip install --force-reinstall Sphinx==4.2.0
+    pip install --force-reinstall docutils==0.16 Sphinx==4.2.0
 
 popd >/dev/null


### PR DESCRIPTION
**Description:**
This pull request fixes the `docutils` version conflict encountered when setting up a micro-ROS workspace with Zephyr, as reported in [issue #739](https://github.com/micro-ROS/micro_ros_setup/issues/739).

### Problem:
The issue arises because `sphinx-rtd-theme` (version 0.5.2) requires `docutils<0.17`, but during the setup process, `docutils 0.17.1` is installed, causing the following error:

```
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
sphinx-rtd-theme 0.5.2 requires docutils<0.17, but you have docutils 0.17.1 which is incompatible.
```

### Solution:
To resolve this, I modified the `create.sh` script located at `config/zephyr/generic/` by pinning the `docutils` version to `0.16`, which is compatible with `sphinx-rtd-theme`. The change is at **line 70** of the script:

```bash
pip install --force-reinstall docutils==0.16 Sphinx==4.2.0
```

### Testing:
The solution was tested in both my local environment (Ubuntu 22.04.5 LTS) and in the official Humble Docker container. The issue was reproducible in both environments, and the fix successfully resolved the version conflict in both cases.

### Related Issue:
This PR fixes [issue #739](https://github.com/micro-ROS/micro_ros_setup/issues/739).