### PR TITLE
Correct Ubuntu Version for ROS Jazzy

### DIFF
--- a/scripts/create_agent_ws.sh
+++ b/scripts/create_agent_ws.sh
@@ -23,4 +23,4 @@ fi
 # populate the workspace
 ros2 run micro_ros_setup create_ws.sh $TARGETDIR $PREFIX/config/agent_ros2_packages.txt $PREFIX/config/agent_uros_packages.repos
 
-rosdep install --os=ubuntu:jammy --from-paths $TARGETDIR -i $TARGETDIR -y --skip-keys="$SKIP"
+rosdep install --os=ubuntu:noble --from-paths $TARGETDIR -i $TARGETDIR -y --skip-keys="$SKIP"

--- a/scripts/create_firmware_ws.sh
+++ b/scripts/create_firmware_ws.sh
@@ -89,7 +89,7 @@ pushd $FW_TARGETDIR >/dev/null
     if [ $RTOS != "host" ]; then
         ros2 run micro_ros_setup create_ws.sh $DEV_WS_DIR $PREFIX/config/$RTOS/dev_ros2_packages.txt \
             $PREFIX/config/$RTOS/dev_uros_packages.repos
-        rosdep install --os=ubuntu:jammy -y --from-paths $DEV_WS_DIR -i $DEV_WS_DIR --rosdistro $ROS_DISTRO --skip-keys="$SKIP"
+        rosdep install --os=ubuntu:noble -y --from-paths $DEV_WS_DIR -i $DEV_WS_DIR --rosdistro $ROS_DISTRO --skip-keys="$SKIP"
 
          # Creating mcu directory
         mkdir mcu_ws
@@ -110,7 +110,7 @@ if [ $RTOS != "host" ]; then
 fi
 
 # Install dependecies for specific platform
-rosdep install --os=ubuntu:jammy -y --from-paths $PREFIX/config/$RTOS/$TARGET_FOLDER -i $PREFIX/config/$RTOS/$TARGET_FOLDER --rosdistro $ROS_DISTRO --skip-keys="$SKIP"
+rosdep install --os=ubuntu:noble -y --from-paths $PREFIX/config/$RTOS/$TARGET_FOLDER -i $PREFIX/config/$RTOS/$TARGET_FOLDER --rosdistro $ROS_DISTRO --skip-keys="$SKIP"
 
 # Creating specific firmware folder
 . $PREFIX/config/$RTOS/$TARGET_FOLDER/create.sh


### PR DESCRIPTION
I met the same issue as in #759, and I found there are three places using incorrect Ubuntu version for ROS Jazzy: 
* https://github.com/micro-ROS/micro_ros_setup/blob/be7582c6a641e1fc8bf2f0ecc10a13df046f73b8/scripts/create_firmware_ws.sh#L113
* https://github.com/micro-ROS/micro_ros_setup/blob/be7582c6a641e1fc8bf2f0ecc10a13df046f73b8/scripts/create_firmware_ws.sh#L92
* https://github.com/micro-ROS/micro_ros_setup/blob/be7582c6a641e1fc8bf2f0ecc10a13df046f73b8/scripts/create_agent_ws.sh#L26
