### PR TITLE
Fix rolling build

### DIFF
--- a/scripts/create_firmware_ws.sh
+++ b/scripts/create_firmware_ws.sh
@@ -102,6 +102,8 @@ popd >/dev/null
 . $(dirname $0)/clean_env.sh
 if [ $RTOS != "host" ]; then
     pushd $FW_TARGETDIR/$DEV_WS_DIR >/dev/null
+        # Fix failing build by ignoring rmw_test_fixture_implementation.
+        touch ros2/ament_cmake_ros/rmw_test_fixture_implementation/COLCON_IGNORE
         colcon build
         set +o nounset
         # source dev workspace


### PR DESCRIPTION
This PR fixes rolling build, that was broken due to new module added to `ament_cmake_ros` (see https://github.com/ros2/ament_cmake_ros/pull/21).

Fix by adding a `COLCON_IGNORE` to this module.