### PR TITLE
Fix CMake error when creating a firmware WS

### DIFF
--- a/scripts/create_firmware_ws.sh
+++ b/scripts/create_firmware_ws.sh
@@ -104,6 +104,8 @@ if [ $RTOS != "host" ]; then
     pushd $FW_TARGETDIR/$DEV_WS_DIR >/dev/null
         # Fix failing build by ignoring rmw_test_fixture_implementation.
         touch ros2/ament_cmake_ros/rmw_test_fixture_implementation/COLCON_IGNORE
+        # Fix failing build by ignoring rmw_test_fixture.
+        touch ros2/ament_cmake_ros/rmw_test_fixture/COLCON_IGNORE
         colcon build
         set +o nounset
         # source dev workspace


### PR DESCRIPTION
### A recent [backport to kilted](https://github.com/ros2/ament_cmake_ros/pull/50) in a `ros2/ament_cmake_ros` repository broke creation of a firmware workspace.

- Hardware description: Custom board - STM32H7
- RTOS: FreeRTOS
- Installation type: micro_ros_setup, generate_lib
- Version: kilted

#### Steps to reproduce the issue
`ros2 run micro_ros_setup create_firmware_ws.sh generate_lib`

#### Actual behavior
Could not find a package configuration file provided by "rmw" with any of
  the following names:
\
    rmwConfig.cmake
    rmw-config.cmake

#### Additional information
- The build was failing on both versions of CMake I tried (3.28.3 and 4.1.1).