### PR TITLE
Apply client workspace compatibility patches for newer ROS 2 interface packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,12 @@ install(
 )
 
 install(
+  DIRECTORY patches DESTINATION share/${PROJECT_NAME} USE_SOURCE_PERMISSIONS
+)
+
+install(
   PROGRAMS
+    scripts/apply_patches.sh
     scripts/create_ws.sh
     scripts/create_agent_ws.sh
     scripts/create_firmware_ws.sh

--- a/config/host/generic/client_host_packages.repos
+++ b/config/host/generic/client_host_packages.repos
@@ -25,7 +25,7 @@ repositories:
   uros/rosidl_typesupport_microxrcedds:
     type: git
     url: https://github.com/micro-ROS/rosidl_typesupport_microxrcedds.git
-    version: jazzy
+    version: jazzy_fix_interfaces
   uros/micro-ROS-demos:
     type: git
     url: https://github.com/micro-ROS/micro-ROS-demos.git

--- a/patches/ros2-core-generators-to-default-generators.patch
+++ b/patches/ros2-core-generators-to-default-generators.patch
@@ -1,0 +1,155 @@
+diff --git a/ros2/rcl_interfaces/action_msgs/CMakeLists.txt b/ros2/rcl_interfaces/action_msgs/CMakeLists.txt
+index b5f34b9..65db062 100644
+--- a/ros2/rcl_interfaces/action_msgs/CMakeLists.txt
++++ b/ros2/rcl_interfaces/action_msgs/CMakeLists.txt
+@@ -15,7 +15,7 @@ find_package(ament_cmake REQUIRED)
+ find_package(builtin_interfaces REQUIRED)
+ # Depend on "core" generators instead of "default" generators
+ # because ROS actions depend on this package
+-find_package(rosidl_core_generators REQUIRED)
++find_package(rosidl_default_generators REQUIRED)
+ find_package(unique_identifier_msgs REQUIRED)
+ 
+ set(msg_files
+@@ -39,6 +39,6 @@ if(BUILD_TESTING)
+   ament_lint_auto_find_test_dependencies()
+ endif()
+ 
+-ament_export_dependencies(rosidl_core_runtime)
++ament_export_dependencies(rosidl_default_runtime)
+ 
+ ament_package()
+diff --git a/ros2/rcl_interfaces/action_msgs/package.xml b/ros2/rcl_interfaces/action_msgs/package.xml
+index 2b0fca7..006029b 100644
+--- a/ros2/rcl_interfaces/action_msgs/package.xml
++++ b/ros2/rcl_interfaces/action_msgs/package.xml
+@@ -15,13 +15,13 @@
+   <author email="michel@ekumenlabs.com">Michel Hidalgo</author>
+ 
+   <buildtool_depend>ament_cmake</buildtool_depend>
+-  <buildtool_depend>rosidl_core_generators</buildtool_depend>
++  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+ 
+   <depend>builtin_interfaces</depend>
+   <depend>service_msgs</depend>
+   <depend>unique_identifier_msgs</depend>
+ 
+-  <exec_depend>rosidl_core_runtime</exec_depend>
++  <exec_depend>rosidl_default_runtime</exec_depend>
+ 
+   <test_depend>ament_lint_auto</test_depend>
+   <test_depend>ament_lint_common</test_depend>
+diff --git a/ros2/rcl_interfaces/builtin_interfaces/CMakeLists.txt b/ros2/rcl_interfaces/builtin_interfaces/CMakeLists.txt
+index 282d38e..67c1339 100644
+--- a/ros2/rcl_interfaces/builtin_interfaces/CMakeLists.txt
++++ b/ros2/rcl_interfaces/builtin_interfaces/CMakeLists.txt
+@@ -14,7 +14,7 @@ endif()
+ find_package(ament_cmake REQUIRED)
+ # Depend on "core" generators instead of "default" generators
+ # because ROS actions depend on this package
+-find_package(rosidl_core_generators REQUIRED)
++find_package(rosidl_default_generators REQUIRED)
+ 
+ rosidl_generate_interfaces(${PROJECT_NAME}
+   "msg/Duration.msg"
+@@ -22,6 +22,6 @@ rosidl_generate_interfaces(${PROJECT_NAME}
+   ADD_LINTER_TESTS
+ )
+ 
+-ament_export_dependencies(rosidl_core_runtime)
++ament_export_dependencies(rosidl_default_runtime)
+ 
+ ament_package()
+diff --git a/ros2/rcl_interfaces/builtin_interfaces/package.xml b/ros2/rcl_interfaces/builtin_interfaces/package.xml
+index 57540d0..2116b3e 100644
+--- a/ros2/rcl_interfaces/builtin_interfaces/package.xml
++++ b/ros2/rcl_interfaces/builtin_interfaces/package.xml
+@@ -15,9 +15,9 @@
+ 
+   <buildtool_depend>ament_cmake</buildtool_depend>
+ 
+-  <buildtool_depend>rosidl_core_generators</buildtool_depend>
++  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+ 
+-  <exec_depend>rosidl_core_runtime</exec_depend>
++  <exec_depend>rosidl_default_runtime</exec_depend>
+ 
+   <test_depend>ament_lint_common</test_depend>
+ 
+diff --git a/ros2/rcl_interfaces/type_description_interfaces/CMakeLists.txt b/ros2/rcl_interfaces/type_description_interfaces/CMakeLists.txt
+index c3ac72b..4374456 100644
+--- a/ros2/rcl_interfaces/type_description_interfaces/CMakeLists.txt
++++ b/ros2/rcl_interfaces/type_description_interfaces/CMakeLists.txt
+@@ -13,7 +13,7 @@ endif()
+ find_package(ament_cmake REQUIRED)
+ # Depend on "core" generators instead of "default" generators
+ # because other generators depend on this.
+-find_package(rosidl_core_generators REQUIRED)
++find_package(rosidl_default_generators REQUIRED)
+ 
+ rosidl_generate_interfaces(${PROJECT_NAME}
+   "msg/Field.msg"
+@@ -31,6 +31,6 @@ if(BUILD_TESTING)
+   ament_lint_auto_find_test_dependencies()
+ endif()
+ 
+-ament_export_dependencies(rosidl_core_runtime)
++ament_export_dependencies(rosidl_default_runtime)
+ 
+ ament_package()
+diff --git a/ros2/rcl_interfaces/type_description_interfaces/package.xml b/ros2/rcl_interfaces/type_description_interfaces/package.xml
+index 3c17a88..72813cb 100644
+--- a/ros2/rcl_interfaces/type_description_interfaces/package.xml
++++ b/ros2/rcl_interfaces/type_description_interfaces/package.xml
+@@ -11,11 +11,11 @@
+ 
+   <buildtool_depend>ament_cmake</buildtool_depend>
+ 
+-  <buildtool_depend>rosidl_core_generators</buildtool_depend>
++  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+ 
+   <depend>service_msgs</depend>
+ 
+-  <exec_depend>rosidl_core_runtime</exec_depend>
++  <exec_depend>rosidl_default_runtime</exec_depend>
+ 
+   <test_depend>ament_lint_auto</test_depend>
+   <test_depend>ament_lint_common</test_depend>
+diff --git a/ros2/unique_identifier_msgs/CMakeLists.txt b/ros2/unique_identifier_msgs/CMakeLists.txt
+index 382b8ec..00498c3 100644
+--- a/ros2/unique_identifier_msgs/CMakeLists.txt
++++ b/ros2/unique_identifier_msgs/CMakeLists.txt
+@@ -15,7 +15,7 @@ endif()
+ find_package(ament_cmake REQUIRED)
+ # Depend on "core" generators instead of "default" generators
+ # because ROS actions depend on this package
+-find_package(rosidl_core_generators REQUIRED)
++find_package(rosidl_default_generators REQUIRED)
+ 
+ set(msg_files
+   "msg/UUID.msg"
+@@ -23,7 +23,7 @@ set(msg_files
+ 
+ rosidl_generate_interfaces(${PROJECT_NAME} ${msg_files})
+ 
+-ament_export_dependencies(rosidl_core_runtime)
++ament_export_dependencies(rosidl_default_runtime)
+ 
+ if(BUILD_TESTING)
+   find_package(ament_lint_auto REQUIRED)
+diff --git a/ros2/unique_identifier_msgs/package.xml b/ros2/unique_identifier_msgs/package.xml
+index 95509ca..2e8f4e4 100644
+--- a/ros2/unique_identifier_msgs/package.xml
++++ b/ros2/unique_identifier_msgs/package.xml
+@@ -19,9 +19,9 @@
+ 
+   <buildtool_depend>ament_cmake</buildtool_depend>
+ 
+-  <buildtool_depend>rosidl_core_generators</buildtool_depend>
++  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+ 
+-  <exec_depend>rosidl_core_runtime</exec_depend>
++  <exec_depend>rosidl_default_runtime</exec_depend>
+ 
+   <test_depend>ament_lint_auto</test_depend>
+   <test_depend>ament_lint_common</test_depend>

--- a/patches/ros2-core-generators-to-default-generators.patch
+++ b/patches/ros2-core-generators-to-default-generators.patch
@@ -11,34 +11,6 @@ index b5f34b9..65db062 100644
  find_package(unique_identifier_msgs REQUIRED)
  
  set(msg_files
-@@ -39,6 +39,6 @@ if(BUILD_TESTING)
-   ament_lint_auto_find_test_dependencies()
- endif()
- 
--ament_export_dependencies(rosidl_core_runtime)
-+ament_export_dependencies(rosidl_default_runtime)
- 
- ament_package()
-diff --git a/ros2/rcl_interfaces/action_msgs/package.xml b/ros2/rcl_interfaces/action_msgs/package.xml
-index 2b0fca7..006029b 100644
---- a/ros2/rcl_interfaces/action_msgs/package.xml
-+++ b/ros2/rcl_interfaces/action_msgs/package.xml
-@@ -15,13 +15,13 @@
-   <author email="michel@ekumenlabs.com">Michel Hidalgo</author>
- 
-   <buildtool_depend>ament_cmake</buildtool_depend>
--  <buildtool_depend>rosidl_core_generators</buildtool_depend>
-+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
- 
-   <depend>builtin_interfaces</depend>
-   <depend>service_msgs</depend>
-   <depend>unique_identifier_msgs</depend>
- 
--  <exec_depend>rosidl_core_runtime</exec_depend>
-+  <exec_depend>rosidl_default_runtime</exec_depend>
- 
-   <test_depend>ament_lint_auto</test_depend>
-   <test_depend>ament_lint_common</test_depend>
 diff --git a/ros2/rcl_interfaces/builtin_interfaces/CMakeLists.txt b/ros2/rcl_interfaces/builtin_interfaces/CMakeLists.txt
 index 282d38e..67c1339 100644
 --- a/ros2/rcl_interfaces/builtin_interfaces/CMakeLists.txt
@@ -49,33 +21,6 @@ index 282d38e..67c1339 100644
  # because ROS actions depend on this package
 -find_package(rosidl_core_generators REQUIRED)
 +find_package(rosidl_default_generators REQUIRED)
- 
- rosidl_generate_interfaces(${PROJECT_NAME}
-   "msg/Duration.msg"
-@@ -22,6 +22,6 @@ rosidl_generate_interfaces(${PROJECT_NAME}
-   ADD_LINTER_TESTS
- )
- 
--ament_export_dependencies(rosidl_core_runtime)
-+ament_export_dependencies(rosidl_default_runtime)
- 
- ament_package()
-diff --git a/ros2/rcl_interfaces/builtin_interfaces/package.xml b/ros2/rcl_interfaces/builtin_interfaces/package.xml
-index 57540d0..2116b3e 100644
---- a/ros2/rcl_interfaces/builtin_interfaces/package.xml
-+++ b/ros2/rcl_interfaces/builtin_interfaces/package.xml
-@@ -15,9 +15,9 @@
- 
-   <buildtool_depend>ament_cmake</buildtool_depend>
- 
--  <buildtool_depend>rosidl_core_generators</buildtool_depend>
-+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
- 
--  <exec_depend>rosidl_core_runtime</exec_depend>
-+  <exec_depend>rosidl_default_runtime</exec_depend>
- 
-   <test_depend>ament_lint_common</test_depend>
- 
 diff --git a/ros2/rcl_interfaces/type_description_interfaces/CMakeLists.txt b/ros2/rcl_interfaces/type_description_interfaces/CMakeLists.txt
 index c3ac72b..4374456 100644
 --- a/ros2/rcl_interfaces/type_description_interfaces/CMakeLists.txt
@@ -86,35 +31,6 @@ index c3ac72b..4374456 100644
  # because other generators depend on this.
 -find_package(rosidl_core_generators REQUIRED)
 +find_package(rosidl_default_generators REQUIRED)
- 
- rosidl_generate_interfaces(${PROJECT_NAME}
-   "msg/Field.msg"
-@@ -31,6 +31,6 @@ if(BUILD_TESTING)
-   ament_lint_auto_find_test_dependencies()
- endif()
- 
--ament_export_dependencies(rosidl_core_runtime)
-+ament_export_dependencies(rosidl_default_runtime)
- 
- ament_package()
-diff --git a/ros2/rcl_interfaces/type_description_interfaces/package.xml b/ros2/rcl_interfaces/type_description_interfaces/package.xml
-index 3c17a88..72813cb 100644
---- a/ros2/rcl_interfaces/type_description_interfaces/package.xml
-+++ b/ros2/rcl_interfaces/type_description_interfaces/package.xml
-@@ -11,11 +11,11 @@
- 
-   <buildtool_depend>ament_cmake</buildtool_depend>
- 
--  <buildtool_depend>rosidl_core_generators</buildtool_depend>
-+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
- 
-   <depend>service_msgs</depend>
- 
--  <exec_depend>rosidl_core_runtime</exec_depend>
-+  <exec_depend>rosidl_default_runtime</exec_depend>
- 
-   <test_depend>ament_lint_auto</test_depend>
-   <test_depend>ament_lint_common</test_depend>
 diff --git a/ros2/unique_identifier_msgs/CMakeLists.txt b/ros2/unique_identifier_msgs/CMakeLists.txt
 index 382b8ec..00498c3 100644
 --- a/ros2/unique_identifier_msgs/CMakeLists.txt
@@ -125,31 +41,3 @@ index 382b8ec..00498c3 100644
  # because ROS actions depend on this package
 -find_package(rosidl_core_generators REQUIRED)
 +find_package(rosidl_default_generators REQUIRED)
- 
- set(msg_files
-   "msg/UUID.msg"
-@@ -23,7 +23,7 @@ set(msg_files
- 
- rosidl_generate_interfaces(${PROJECT_NAME} ${msg_files})
- 
--ament_export_dependencies(rosidl_core_runtime)
-+ament_export_dependencies(rosidl_default_runtime)
- 
- if(BUILD_TESTING)
-   find_package(ament_lint_auto REQUIRED)
-diff --git a/ros2/unique_identifier_msgs/package.xml b/ros2/unique_identifier_msgs/package.xml
-index 95509ca..2e8f4e4 100644
---- a/ros2/unique_identifier_msgs/package.xml
-+++ b/ros2/unique_identifier_msgs/package.xml
-@@ -19,9 +19,9 @@
- 
-   <buildtool_depend>ament_cmake</buildtool_depend>
- 
--  <buildtool_depend>rosidl_core_generators</buildtool_depend>
-+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
- 
--  <exec_depend>rosidl_core_runtime</exec_depend>
-+  <exec_depend>rosidl_default_runtime</exec_depend>
- 
-   <test_depend>ament_lint_auto</test_depend>
-   <test_depend>ament_lint_common</test_depend>

--- a/patches/ros2-example-interfaces-action-deps.patch
+++ b/patches/ros2-example-interfaces-action-deps.patch
@@ -1,0 +1,38 @@
+diff --git a/ros2/example_interfaces/CMakeLists.txt b/ros2/example_interfaces/CMakeLists.txt
+index e7dae2c..033eda0 100644
+--- a/ros2/example_interfaces/CMakeLists.txt
++++ b/ros2/example_interfaces/CMakeLists.txt
+@@ -12,7 +12,10 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+ endif()
+ 
+ find_package(ament_cmake REQUIRED)
++find_package(action_msgs REQUIRED)
++find_package(builtin_interfaces REQUIRED)
+ find_package(rosidl_default_generators REQUIRED)
++find_package(unique_identifier_msgs REQUIRED)
+ 
+ rosidl_generate_interfaces(${PROJECT_NAME}
+   "action/Fibonacci.action"
+@@ -48,6 +51,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
+   "srv/AddTwoInts.srv"
+   "srv/SetBool.srv"
+   "srv/Trigger.srv"
++  DEPENDENCIES builtin_interfaces unique_identifier_msgs
+ )
+ 
+ install(FILES mapping_rules.yaml DESTINATION share/${PROJECT_NAME})
+diff --git a/ros2/example_interfaces/package.xml b/ros2/example_interfaces/package.xml
+index f127a53..31f8653 100644
+--- a/ros2/example_interfaces/package.xml
++++ b/ros2/example_interfaces/package.xml
+@@ -17,6 +17,10 @@
+ 
+   <buildtool_depend>rosidl_default_generators</buildtool_depend>
+ 
++  <depend>action_msgs</depend>
++  <depend>builtin_interfaces</depend>
++  <depend>unique_identifier_msgs</depend>
++
+   <exec_depend>rosidl_default_runtime</exec_depend>
+ 
+   <member_of_group>rosidl_interface_packages</member_of_group>

--- a/patches/ros2-test-msgs-action-deps.patch
+++ b/patches/ros2-test-msgs-action-deps.patch
@@ -1,0 +1,40 @@
+diff --git a/ros2/rcl_interfaces/test_msgs/CMakeLists.txt b/ros2/rcl_interfaces/test_msgs/CMakeLists.txt
+index 433833b..b2472b8 100644
+--- a/ros2/rcl_interfaces/test_msgs/CMakeLists.txt
++++ b/ros2/rcl_interfaces/test_msgs/CMakeLists.txt
+@@ -17,9 +17,11 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+ endif()
+ 
+ find_package(ament_cmake REQUIRED)
++find_package(action_msgs REQUIRED)
+ find_package(builtin_interfaces REQUIRED)
+ find_package(rosidl_default_generators REQUIRED)
+ find_package(test_interface_files REQUIRED)
++find_package(unique_identifier_msgs REQUIRED)
+ 
+ # TODO(sloretz) Change to test_msgs_interfaces when ros2/rosidl_typesupport#120 is fixed
+ rosidl_generate_interfaces(test_msgs
+@@ -29,7 +31,7 @@ rosidl_generate_interfaces(test_msgs
+   ${test_interface_files_IDL_FILES}
+   "msg/Builtins.msg"
+   "action/NestedMessage.action"
+-  DEPENDENCIES builtin_interfaces
++  DEPENDENCIES builtin_interfaces unique_identifier_msgs
+   ADD_LINTER_TESTS
+ )
+ 
+diff --git a/ros2/rcl_interfaces/test_msgs/package.xml b/ros2/rcl_interfaces/test_msgs/package.xml
+index 67fe631..0f76490 100644
+--- a/ros2/rcl_interfaces/test_msgs/package.xml
++++ b/ros2/rcl_interfaces/test_msgs/package.xml
+@@ -17,8 +17,10 @@
+ 
+   <buildtool_depend>rosidl_default_generators</buildtool_depend>
+ 
++  <depend>action_msgs</depend>
+   <build_depend>builtin_interfaces</build_depend>
+   <build_depend>test_interface_files</build_depend>
++  <depend>unique_identifier_msgs</depend>
+ 
+   <exec_depend>builtin_interfaces</exec_depend>
+   <exec_depend>rosidl_default_runtime</exec_depend>

--- a/scripts/apply_patches.sh
+++ b/scripts/apply_patches.sh
@@ -34,8 +34,39 @@ if [ -z "${PATCH_DIR}" ]; then
     exit 255
 fi
 
+patch_targets_workspace() {
+    local patch_file=$1
+    local candidate_path=""
+    local repo_path=""
+    local saw_diff=0
+
+    while read -r _ _ old_path new_path; do
+        saw_diff=1
+        old_path=${old_path#a/}
+        new_path=${new_path#b/}
+
+        for candidate_path in "${old_path}" "${new_path}"; do
+            repo_path=$(printf '%s\n' "${candidate_path}" | cut -d/ -f1-2)
+            if [ -n "${repo_path}" ] && [ -d "${WORKSPACE_DIR}/${repo_path}" ]; then
+                return 0
+            fi
+        done
+    done < <(grep '^diff --git a/' "${patch_file}" || true)
+
+    if [ "${saw_diff}" -eq 0 ]; then
+        return 0
+    fi
+
+    return 1
+}
+
 apply_patch_file() {
     local patch_file=$1
+
+    if ! patch_targets_workspace "${patch_file}"; then
+        echo "Skipping $(basename "${patch_file}") (workspace does not contain the patched repository)"
+        return
+    fi
 
     if patch --batch --forward -p1 -d "${WORKSPACE_DIR}" --dry-run < "${patch_file}" >/dev/null 2>&1; then
         echo "Applying $(basename "${patch_file}")"
@@ -48,8 +79,7 @@ apply_patch_file() {
         return
     fi
 
-    echo "Error: Failed to apply $(basename "${patch_file}") in ${WORKSPACE_DIR}"
-    exit 1
+    echo "Warning: Failed to apply $(basename "${patch_file}") in ${WORKSPACE_DIR}" >&2
 }
 
 shopt -s nullglob

--- a/scripts/apply_patches.sh
+++ b/scripts/apply_patches.sh
@@ -30,7 +30,7 @@ if [ ! -d "${WORKSPACE_DIR}" ]; then
 fi
 
 if [ -z "${PATCH_DIR}" ]; then
-    echo "Error: Patch directory '${PATCH_DIR}' does not exist"
+    echo "Error: Patch directory not found (searched: ${SCRIPT_DIR}/../../share/micro_ros_setup/patches, ${SCRIPT_DIR}/../share/micro_ros_setup/patches, ${SCRIPT_DIR}/../patches)"
     exit 255
 fi
 

--- a/scripts/apply_patches.sh
+++ b/scripts/apply_patches.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+set -e
+set -o nounset
+set -o pipefail
+
+if [ $# -ne 1 ]; then
+    echo "Syntax: $0 <workspace_dir>"
+    exit 255
+fi
+
+WORKSPACE_DIR=$1
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+PATCH_DIR=""
+
+for candidate in \
+    "${SCRIPT_DIR}/../../share/micro_ros_setup/patches" \
+    "${SCRIPT_DIR}/../share/micro_ros_setup/patches" \
+    "${SCRIPT_DIR}/../patches"
+do
+    if [ -d "${candidate}" ]; then
+        PATCH_DIR="${candidate}"
+        break
+    fi
+done
+
+if [ ! -d "${WORKSPACE_DIR}" ]; then
+    echo "Error: Workspace '${WORKSPACE_DIR}' does not exist"
+    exit 255
+fi
+
+if [ -z "${PATCH_DIR}" ]; then
+    echo "Error: Patch directory '${PATCH_DIR}' does not exist"
+    exit 255
+fi
+
+apply_patch_file() {
+    local patch_file=$1
+
+    if patch --batch --forward -p1 -d "${WORKSPACE_DIR}" --dry-run < "${patch_file}" >/dev/null 2>&1; then
+        echo "Applying $(basename "${patch_file}")"
+        patch --batch --forward -p1 -d "${WORKSPACE_DIR}" < "${patch_file}" >/dev/null
+        return
+    fi
+
+    if patch --batch --reverse -p1 -d "${WORKSPACE_DIR}" --dry-run < "${patch_file}" >/dev/null 2>&1; then
+        echo "Skipping $(basename "${patch_file}") (already applied)"
+        return
+    fi
+
+    echo "Error: Failed to apply $(basename "${patch_file}") in ${WORKSPACE_DIR}"
+    exit 1
+}
+
+shopt -s nullglob
+for patch_file in "${PATCH_DIR}"/*.patch; do
+    apply_patch_file "${patch_file}"
+done

--- a/scripts/create_ws.sh
+++ b/scripts/create_ws.sh
@@ -44,6 +44,6 @@ curl -s https://raw.githubusercontent.com/ros2/ros2/jazzy/ros2.repos |\
     ros2 run micro_ros_setup yaml_filter.py ${PACKAGES} > ros2.repos
 vcs import --input ros2.repos --skip-existing
 vcs import --input $REPOS --skip-existing
-"$(dirname "$0")/apply_patches.sh" "$(pwd)"
+bash "$(dirname "$0")/apply_patches.sh" "$(pwd)"
 
 popd >/dev/null

--- a/scripts/create_ws.sh
+++ b/scripts/create_ws.sh
@@ -44,6 +44,6 @@ curl -s https://raw.githubusercontent.com/ros2/ros2/jazzy/ros2.repos |\
     ros2 run micro_ros_setup yaml_filter.py ${PACKAGES} > ros2.repos
 vcs import --input ros2.repos --skip-existing
 vcs import --input $REPOS --skip-existing
+"$(dirname "$0")/apply_patches.sh" "$(pwd)"
 
 popd >/dev/null
-


### PR DESCRIPTION
This PR adds compatibility patching in micro_ros_setup for imported ROS 2 client workspaces so they can be built successfully with Micro XRCE-DDS typesupport.

Recent ROS 2 interface packages use patterns that work in a full ROS 2 build but can break in the micro-ROS firmware workspace. In particular:

- some foundational interface packages use rosidl_core_generators, which prevents the Micro XRCE-DDS generators from producing the required typesupport for downstream action-related dependencies in this environment
- some action-containing interface packages do not explicitly declare the dependencies that become relevant once Micro XRCE-DDS typesupport is generated and linked in the firmware workspace

This PR keeps those fixes local to micro-ROS by shipping patch files in micro_ros_setup and applying them when the workspace is created/imported, instead of requiring direct changes in upstream ROS 2 repositories as part of the normal micro-ROS flow.

**What changed**

- Add patch assets for imported ROS 2 packages
- Apply those patches from the workspace creation flow
- Cover the interface packages needed for successful Micro XRCE-DDS client firmware builds

**Patch scope**

The compatibility patches address:
- switching selected interface packages from rosidl_core_generators to rosidl_default_generators
- updating matching runtime dependencies where needed
- adding explicit action-related dependencies in packages that otherwise resolve incorrectly in the micro-ROS workspace

**Why**
As a micro-ROS maintainer, we need the fix to live in micro-ROS-owned repositories while still allowing the generated firmware workspace to build against current ROS 2 interface definitions.

**TODO**

- [ ] Merge https://github.com/micro-ROS/rosidl_typesupport_microxrcedds/pull/82