### PR TITLE
Pre-build msg packages with micro-ROS typesupport before full build

### DIFF
--- a/config/host/generic/build.sh
+++ b/config/host/generic/build.sh
@@ -6,4 +6,25 @@ set +o nounset
 . install/local_setup.bash
 set -o nounset
 
+# Pre-build foundational message packages with the workspace microxrcedds type supports
+# already in the path.  These packages are implicit dependencies of many interface
+# packages (added by rosidl's action/service expansion), but are NOT declared in those
+# packages' package.xml files.  Without pre-building them in the workspace, cmake would
+# find the system /opt/ros/jazzy versions (which have no microxrcedds type support) and
+# the generated libraries would fail to link.
+#
+# Build order matters:
+#   builtin_interfaces      - no workspace deps
+#   unique_identifier_msgs  - no workspace deps (UUID.msg only)
+#   service_msgs            - depends on builtin_interfaces (ServiceEventInfo.msg)
+#   action_msgs             - depends on all three above; has CancelGoal.srv
+colcon build --packages-select builtin_interfaces unique_identifier_msgs service_msgs action_msgs --metas src --cmake-args -DBUILD_TESTING=OFF -DBUILD_SHARED_LIBS=ON $@
+
+# Re-source so the pre-built packages appear in CMAKE_PREFIX_PATH *before* the system
+# /opt/ros/jazzy path.  This ensures cmake prefers workspace versions (with microxrcedds
+# type support) when configuring packages in the full workspace build below.
+set +o nounset
+. install/local_setup.bash
+set -o nounset
+
 colcon build --metas src --cmake-args -DBUILD_TESTING=OFF -DBUILD_SHARED_LIBS=ON $@


### PR DESCRIPTION
## Problem

The host build (`config/host/generic/build.sh`) builds the micro-ROS
XRCE-DDS typesupport generators (`rosidl_typesupport_microxrcedds_c`/`_cpp`),
sources them, then runs a single full-workspace `colcon build`.

`builtin_interfaces`, `unique_identifier_msgs`, `service_msgs`, and
`action_msgs` are pulled in implicitly by rosidl's action/service code
expansion for many interface packages, but those dependent packages don't
declare them in `package.xml`. As a result, colcon's normal
dependency-ordered build can resolve these four packages from the system
`/opt/ros/jazzy` install instead of building them in the workspace.

The system versions were built without `rosidl_typesupport_microxrcedds_c`
available (it's a micro-ROS-only generator, not part of stock ROS 2), so
they have no micro-ROS XRCE-DDS typesupport compiled in. Any package that
needs microxrcedds typesupport for these message types then fails to link.

## Fix

- Explicitly pre-build `builtin_interfaces`, `unique_identifier_msgs`,
  `service_msgs`, `action_msgs` (in that dependency order) after the
  microxrcedds typesupport generators are already on the path, so rosidl
  regenerates and compiles the microxrcedds typesupport for them.
- Re-source `install/local_setup.bash` afterward so `CMAKE_PREFIX_PATH`
  prefers these workspace-built versions over `/opt/ros/jazzy` in the
  subsequent full workspace build.

## Testing

- [ ] Host build completes without link errors for packages depending on
      action/service interfaces.
- [ ] Confirm the resulting `install/` typesupport libs for the four
      packages include microxrcedds symbols (not just the system ones).
