### PR TITLE
Fix CI

### DIFF
--- a/config/freertos/esp32/create.sh
+++ b/config/freertos/esp32/create.sh
@@ -32,6 +32,10 @@ pushd $FW_TARGETDIR >/dev/null
 
         eval $(python3 $FW_TARGETDIR/toolchain/esp-idf/tools/idf_tools.py export --prefer-system)
 
+        # ESP-IDF v4.1 tooling imports pkg_resources, which setuptools dropped in release 81.
+        # Its requirements.txt only pins setuptools>=21, so pin it back here.
+        python3 -m pip install "setuptools<81" pyyaml
+
         . $IDF_PATH/export.sh
 
         pip3 install catkin_pkg lark-parser colcon-common-extensions

--- a/config/raspbian/generic/configure.sh
+++ b/config/raspbian/generic/configure.sh
@@ -3,7 +3,8 @@
 pushd $FW_TARGETDIR >/dev/null
     rm -rf mcu_ws/*
     cp raspbian_apps/toolchain.cmake mcu_ws/
-    curl -s https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos |\
+    # ROS_DISTRO SPECIFIC
+    curl -s https://raw.githubusercontent.com/ros2/ros2/kilted/ros2.repos |\
         ros2 run micro_ros_setup yaml_filter.py raspbian_apps/$CONFIG_NAME/ros2_repos.filter > ros2.repos
     vcs import --input ros2.repos mcu_ws/ && rm ros2.repos
 


### PR DESCRIPTION
Fix issues in CI:
- ESP-IDF v4.1 tooling imports pkg_resources, which setuptools dropped in release 81. Fixed pinning the version.
- Raspbian workspace was being built for the wrong ROS distro.