### PR TITLE
Document apt index refresh for rosdep in minimal ROS images

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -33,3 +33,5 @@ Robert Wilbrandt <robert@stamm-wilbrandt.de>
 
 Boston Engineering
     Connor Lansdale <clansdale@boston-engineering.com>
+
+yurekami <yurekami@users.noreply.github.com>

--- a/README.md
+++ b/README.md
@@ -122,6 +122,19 @@ colcon build
 source install/local_setup.bash
 ```
 
+If you are building inside a minimal Docker image such as `ros:jazzy-ros-core-noble`,
+refresh the APT package index in the same `RUN` step before invoking `rosdep install`.
+The official ROS images clear `/var/lib/apt/lists/*`, so skipping `apt-get update`
+can make `rosdep` fail when it tries to install system packages such as
+`libcurl4-openssl-dev`.
+
+```dockerfile
+RUN apt-get update && \
+    . /opt/ros/$ROS_DISTRO/setup.sh && \
+    rosdep update && \
+    rosdep install --from-paths src --ignore-src -y
+```
+
 Once the package is built, the firmware scripts are ready to run.
 
 You can find tutorials for moving your first steps with micro-ROS on an RTOS in the [micro-ROS webpage](https://micro-ros.github.io/docs/tutorials/core/first_application_rtos/).


### PR DESCRIPTION
## Summary

Document the `apt-get update` step required before `rosdep install` when building `micro_ros_setup` in minimal ROS Docker images such as `ros:jazzy-ros-core-noble`.

## Root cause

- `micro_ros_setup` depends on the rosdep key `curl`
- `rosdistro` correctly resolves that key on Ubuntu to `libcurl4-openssl-dev`
- official ROS Docker images clear `/var/lib/apt/lists/*`
- a derived image that invokes `rosdep install` without first refreshing APT indexes cannot locate the package

On Ubuntu 24.04 Noble, `libcurl4-dev` is only a virtual package while `libcurl4-openssl-dev` is the concrete installable package, so changing the rosdep mapping would be incorrect.

## Verification

- reproduced package resolution behavior on WSL Ubuntu 24.04
- reproduced failure with an empty APT lists directory
- `git diff --check`

The `NOTICE` entry follows this repository's first-time contributor requirement.

Fixes #782